### PR TITLE
Basis for Nystrom methods

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [weakdeps]
@@ -19,6 +20,7 @@ IntiVTKExt = "WriteVTK"
 
 [compat]
 Gmsh = "0.2"
+SpecialFunctions = "2"
 StaticArrays = "1"
 WriteVTK = "1"
 julia = "1.6"

--- a/src/Inti.jl
+++ b/src/Inti.jl
@@ -4,6 +4,7 @@ const PROJECT_ROOT = pkgdir(Inti)
 
 using LinearAlgebra
 using StaticArrays
+using SpecialFunctions
 using Printf
 
 # helper functions
@@ -20,6 +21,10 @@ include("entities.jl")
 include("domain.jl")
 include("mesh.jl")
 include("quadrature.jl")
+
+# Nyström methods
+include("kernels.jl")
+include("nystrom.jl")
 
 # # integral operators
 # include("integral_potentials.jl")

--- a/src/kernels.jl
+++ b/src/kernels.jl
@@ -1,0 +1,274 @@
+"""
+    abstract type AbstractKernel{T}
+
+A kernel functions `K` with the signature `K(target,source)::T`.
+
+See also: [`GenericKernel`](@ref), [`SingleLayerKernel`](@ref), [`DoubleLayerKernel`](@ref), [`AdjointDoubleLayerKernel`](@ref), [`HyperSingularKernel`](@ref)
+"""
+abstract type AbstractKernel{T} end
+
+return_type(::AbstractKernel{T}) where {T} = T
+
+"""
+    struct GenericKernel{T,F} <: AbstractKernel{T}
+
+An [`AbstractKernel`](@ref) with `kernel` of type `F`.
+"""
+struct GenericKernel{T,F} <: AbstractKernel{T}
+    kernel::F
+end
+
+"""
+    abstract type AbstractPDE{N}
+
+A partial differential equation in dimension `N`. `AbstractPDE` types are used
+to define `AbstractPDEKernel`s.
+"""
+abstract type AbstractPDE{N} end
+
+ambient_dimension(::AbstractPDE{N}) where {N} = N
+
+"""
+    abstract type AbstractPDEKernel{T,Op} <: AbstractKernel{T}
+
+An [`AbstractKernel`](@ref) with an associated `pde::Op` field.
+"""
+abstract type AbstractPDEKernel{T,Op} <: AbstractKernel{T} end
+
+"""
+    pde(K::AbstractPDEKernel)
+
+Return the underlying `AbstractPDE` when `K` correspond to the kernel related to
+the underlying Greens function of a PDE.
+"""
+pde(k::AbstractPDEKernel) = k.pde
+
+parameters(k::AbstractPDEKernel) = parameters(pde(k))
+
+# convenient constructor
+function (K::Type{<:AbstractPDEKernel})(op, T::DataType=default_kernel_eltype(op))
+    return K{T,typeof(op)}(op)
+end
+
+"""
+    struct SingleLayerKernel{T,Op} <: AbstractPDEKernel{T,Op}
+
+The free-space single-layer kernel (i.e. the fundamental solution) of an `OP <:
+AbstractPDE`.
+"""
+struct SingleLayerKernel{T,Op} <: AbstractPDEKernel{T,Op}
+    pde::Op
+end
+
+"""
+    struct DoubleLayerKernel{T,Op} <: AbstractPDEKernel{T,Op}
+
+Given an operator `Op`, construct its free-space double-layer kernel. This
+corresponds to the `γ₁` trace of the [`SingleLayerKernel`](@ref). For operators
+such as [`Laplace`](@ref) or [`Helmholtz`](@ref), this is simply the normal
+derivative of the fundamental solution respect to the source variable.
+"""
+struct DoubleLayerKernel{T,Op} <: AbstractPDEKernel{T,Op}
+    pde::Op
+end
+
+"""
+    struct AdjointDoubleLayerKernel{T,Op} <: AbstractPDEKernel{T,Op}
+
+Given an operator `Op`, construct its free-space adjoint double-layer kernel.
+This corresponds to the `transpose(γ₁,ₓ[G])`, where `G` is the
+[`SingleLayerKernel`](@ref). For operators such as [`Laplace`](@ref) or
+[`Helmholtz`](@ref), this is simply the normal derivative of the fundamental
+solution respect to the target variable.
+"""
+struct AdjointDoubleLayerKernel{T,Op} <: AbstractPDEKernel{T,Op}
+    pde::Op
+end
+
+"""
+    struct HyperSingularKernel{T,Op} <: AbstractPDEKernel{T,Op}
+
+Given an operator `Op`, construct its free-space hypersingular kernel. This
+corresponds to the `transpose(γ₁,ₓγ₁[G])`, where `G` is the
+[`SingleLayerKernel`](@ref). For operators such as [`Laplace`](@ref) or
+[`Helmholtz`](@ref), this is simply the normal derivative of the fundamental
+solution respect to the target variable of the `DoubleLayerKernel`.
+"""
+struct HyperSingularKernel{T,Op} <: AbstractPDEKernel{T,Op}
+    pde::Op
+end
+
+################################################################################
+################################# LAPLACE ######################################
+################################################################################
+
+"""
+    struct Laplace{N}
+
+Laplace equation in `N` dimension: Δu = 0.
+"""
+struct Laplace{N} <: AbstractPDE{N} end
+
+Laplace(; dim=3) = Laplace{dim}()
+
+function Base.show(io::IO, pde::Laplace)
+    return print(io, "Δu = 0")
+end
+
+default_kernel_eltype(::Laplace) = Float64
+default_density_eltype(::Laplace) = Float64
+
+parameters(::Laplace) = nothing
+
+function (SL::SingleLayerKernel{T,Laplace{N}})(target, source,
+                                               r=coords(target) - coords(source))::T where {N,
+                                                                                            T}
+    d = norm(r)
+    filter = !(d == 0)
+    if N == 2
+        return filter * (-1 / (2π) * log(d))
+    elseif N == 3
+        return filter * (1 / (4π) / d)
+    else
+        notimplemented()
+    end
+end
+
+function (DL::DoubleLayerKernel{T,Laplace{N}})(target, source,
+                                               r=coords(target) - coords(source))::T where {N,
+                                                                                            T}
+    ny = normal(source)
+    d = norm(r)
+    filter = !(d == 0)
+    if N == 2
+        return filter * (1 / (2π) / (d^2) * dot(r, ny))
+    elseif N == 3
+        return filter * (1 / (4π) / (d^3) * dot(r, ny))
+    else
+        notimplemented()
+    end
+end
+
+function (ADL::AdjointDoubleLayerKernel{T,Laplace{N}})(target, source,
+                                                       r=coords(target) - coords(source))::T where {N,
+                                                                                                    T}
+    nx = normal(target)
+    d = norm(r)
+    filter = !(d == 0)
+    if N == 2
+        return filter * (-1 / (2π) / (d^2) * dot(r, nx))
+    elseif N == 3
+        return filter * (-1 / (4π) / (d^3) * dot(r, nx))
+    end
+end
+
+function (HS::HyperSingularKernel{T,Laplace{N}})(target, source,
+                                                 r=coords(target) - coords(source))::T where {N,
+                                                                                              T}
+    nx = normal(target)
+    ny = normal(source)
+    d = norm(r)
+    d == 0 && (return zero(T))
+    if N == 2
+        return 1 / (2π) / (d^2) * transpose(nx) * ((I - 2 * r * transpose(r) / d^2) * ny)
+    elseif N == 3
+        ID = SMatrix{3,3,Float64,9}(1, 0, 0, 0, 1, 0, 0, 0, 1)
+        RRT = r * transpose(r) # r ⊗ rᵗ
+        return 1 / (4π) / (d^3) * transpose(nx) * ((ID - 3 * RRT / d^2) * ny)
+    end
+end
+
+################################################################################
+################################# Helmholtz ####################################
+################################################################################
+
+"""
+    struct Helmholtz{N,T}
+
+Helmholtz equation in `N` dimensions: Δu + k²u = 0.
+"""
+struct Helmholtz{N,K} <: AbstractPDE{N}
+    k::K
+end
+
+Helmholtz(; k, dim=3) = Helmholtz{dim,typeof(k)}(k)
+
+function Base.show(io::IO, ::Helmholtz)
+    # k = parameters(pde)
+    return print(io, "Δu + k² u = 0")
+end
+
+parameters(pde::Helmholtz) = pde.k
+
+default_kernel_eltype(::Helmholtz) = ComplexF64
+default_density_eltype(::Helmholtz) = ComplexF64
+
+function (SL::SingleLayerKernel{T,<:Helmholtz{N}})(target, source)::T where {N,T}
+    x = coords(target)
+    y = coords(source)
+    k = parameters(SL)
+    r = x - y
+    d = norm(r)
+    filter = !(d == 0)
+    if N == 2
+        return filter * (im / 4 * hankelh1(0, k * d))
+    elseif N == 3
+        return filter * (1 / (4π) / d * exp(im * k * d))
+    end
+end
+
+# Double Layer Kernel
+function (DL::DoubleLayerKernel{T,<:Helmholtz{N}})(target, source)::T where {N,T}
+    x, y, ny = coords(target), coords(source), normal(source)
+    k = parameters(DL)
+    r = x - y
+    d = norm(r)
+    filter = !(d == 0)
+    if N == 2
+        val = im * k / 4 / d * hankelh1(1, k * d) .* dot(r, ny)
+        return filter * val
+    elseif N == 3
+        val = 1 / (4π) / d^2 * exp(im * k * d) * (-im * k + 1 / d) * dot(r, ny)
+        return filter * val
+    end
+end
+
+# Adjoint double Layer Kernel
+function (ADL::AdjointDoubleLayerKernel{T,<:Helmholtz{N}})(target, source)::T where {N,T}
+    x, y, nx = coords(target), coords(source), normal(target)
+    k = parameters(ADL)
+    r = x - y
+    d = norm(r)
+    filter = !(d == 0)
+    if N == 2
+        val = -im * k / 4 / d * hankelh1(1, k * d) .* dot(r, nx)
+        return filter * val
+    elseif N == 3
+        val = -1 / (4π) / d^2 * exp(im * k * d) * (-im * k + 1 / d) * dot(r, nx)
+        return filter * val
+    end
+end
+
+# Hypersingular kernel
+function (HS::HyperSingularKernel{T,S})(target, source)::T where {T,S<:Helmholtz}
+    x, y, nx, ny = coords(target), coords(source), normal(target), normal(source)
+    N = ambient_dimension(pde(HS))
+    k = parameters(pde(HS))
+    r = x - y
+    d = norm(r)
+    filter = !(d == 0)
+    if N == 2
+        RRT = r * transpose(r) # r ⊗ rᵗ
+        # TODO: rewrite the operation below in a more clear/efficient way
+        val = transpose(nx) * ((-im * k^2 / 4 / d^2 * hankelh1(2, k * d) * RRT +
+                                im * k / 4 / d * hankelh1(1, k * d) * I) * ny)
+        return filter * val
+    elseif N == 3
+        RRT = r * transpose(r) # r ⊗ rᵗ
+        term1 = 1 / (4π) / d^2 * exp(im * k * d) * (-im * k + 1 / d) * I
+        term2 = RRT / d * exp(im * k * d) / (4 * π * d^4) *
+                (3 * (d * im * k - 1) + d^2 * k^2)
+        val = transpose(nx) * (term1 + term2) * ny
+        return filter * val
+    end
+end

--- a/src/nystrom.jl
+++ b/src/nystrom.jl
@@ -1,0 +1,161 @@
+"""
+    struct NystromDensity{N,T,V} <: AbstractVector{V}
+
+Values of type `V` on a `Quadrature` in `N` dimensions.
+"""
+struct NystromDensity{N,T,V} <: AbstractVector{V}
+    values::Vector{V}
+    quadrature::Quadrature{N,T}
+end
+
+Base.size(σ::NystromDensity) = size(σ.values)
+Base.getindex(σ::NystromDensity, args...) = getindex(σ.values, args...)
+Base.setindex!(σ::NystromDensity, args...) = setindex!(σ.values, args...)
+
+"""
+    NystromDensity(f::Function, Q::Quadrature)
+
+Return a `NystromDensity` with values `f(q)` at the quadrature nodes of `Q`.
+
+Note that the argument passsed to `f` is a [`QuadratureNode`](@ref), so that `f`
+may depend on quantities other than the [`coords`](@ref) of the quadrature node
+(such as the [`normal`](@ref) vector).
+
+See also: [`QuadratureNode`](@ref)
+"""
+function NystromDensity(f::Function, X::Quadrature{N,T}) where {N,T}
+    vals = [f(dof) for dof in X]
+    V = eltype(vals)
+    return NystromDensity{N,T,V}(vals, X)
+end
+
+"""
+    struct IntegralPotential
+
+Represent a potential given by a `kernel` and a `quadrature` over which
+integration is performed.
+
+`IntegralPotential`s are created using `IntegralPotential(kernel, quadrature)`.
+
+Evaluating an integral potential requires a density `σ` (defined over the
+quadrature nodes of the source mesh) and a point `x` at which to evaluate the
+integral
+```math
+\\int_{\\Gamma} K(\boldsymbol{x},\boldsymbol{y})\\sigma(y) ds_y, x \\not \\in \\Gamma
+```
+
+"""
+struct IntegralPotential
+    kernel::AbstractKernel
+    quadrature::AbstractMesh
+end
+
+function Base.getindex(pot::IntegralPotential, σ::AbstractVector)
+    K = pot.kernel
+    Q = pot.quadrature.qnodes
+    return (x) -> _evaluate_potential(K, σ, x, Q)
+end
+
+@noinline function _evaluate_potential(K, σ, x, Q)
+    iter = zip(Q, σ)
+    out = sum(iter) do (qi, σi)
+        wi = weight(qi)
+        return K(x, qi) * σi * wi
+    end
+    return out
+end
+
+"""
+    single_layer_potential(pde::AbstractPDE, quad::Quadrature)
+
+Build an [`IntegralPotential`](@ref) corresponding to the single-layer potential
+over `quad` associated to a given PDE.
+"""
+function single_layer_potential(op::AbstractPDE, quad)
+    return IntegralPotential(SingleLayerKernel(op), quad)
+end
+
+"""
+    double_layer_potential(pde::AbstractPDE, quad::Quadrature)
+
+Build an [`IntegralPotential`](@ref) corresponding to the double-layer potential
+over `quad` associated to a given PDE.
+"""
+function double_layer_potential(op::AbstractPDE, quad)
+    return IntegralPotential(DoubleLayerKernel(op), quad)
+end
+
+"""
+    struct IntegralOperator{T} <: AbstractMatrix{T}
+
+A discrete linear integral operator given by
+```math
+I[u](x) = \\int_{\\Gamma\\_s} K(x,y)u(y) ds_y, x \\in \\Gamma_{t}
+```
+where ``\\Gamma_s`` and ``\\Gamma_t`` are the source and target domains, respectively.
+"""
+struct IntegralOperator{T} <: AbstractMatrix{T}
+    kernel::AbstractKernel
+    # since the target can be as simple as a vector of points, leave it untyped
+    target
+    # the source, on the other hand, has to be a quadrature
+    source::Quadrature
+end
+
+kernel(iop::IntegralOperator) = iop.kernel
+
+function IntegralOperator(k, X, Y::Quadrature=X)
+    T = return_type(k)
+    msg = """IntegralOperator of nonbits being created"""
+    isbitstype(T) || (@warn msg)
+    return IntegralOperator{T}(k, X, Y)
+end
+
+Base.size(iop::IntegralOperator) = (length(iop.target), length(iop.source))
+
+function Base.getindex(iop::IntegralOperator, i::Integer, j::Integer)
+    k = kernel(iop)
+    return k(iop.target[i], iop.source[j]) * weight(iop.source[j])
+end
+
+function Base.Matrix(iop::IntegralOperator{T}) where {T}
+    m,n = size(iop)
+    K = kernel(iop)
+    out = Matrix{T}(undef, m, n)
+    _iop_to_matrix!(out, K, iop.target, iop.source)
+    return out
+end
+@noinline function _iop_to_matrix!(out, K, X, Y::Quadrature)
+    Threads.@threads for j in 1:length(Y)
+        for i in 1:length(X)
+            out[i, j] = K(X[i], Y[j]) * weight(Y[j])
+        end
+    end
+    return out
+end
+
+# convenience constructors
+single_layer_operator(op::AbstractPDE, X, Y=X) = IntegralOperator(SingleLayerKernel(op), X, Y)
+double_layer_operator(op::AbstractPDE, X, Y=X) = IntegralOperator(DoubleLayerKernel(op), X, Y)
+
+function adjoint_double_layer_operator(op::AbstractPDE, X, Y=X)
+    return IntegralOperator(AdjointDoubleLayerKernel(op), X, Y)
+end
+function hypersingular_operator(op::AbstractPDE, X, Y=X)
+    return IntegralOperator(HyperSingularKernel(op), X, Y)
+end
+
+# Applying Laplace's double-layer to a constant will yield either 1 or -1,
+# depending on whether the target point is inside or outside the obstacle.
+# Assumes `quad` is the quadrature of a closed curve/surface
+function isinside(x::SVector, quad::Quadrature, s=1)
+    N = ambient_dimension(quad)
+    pde = Laplace(; dim=N)
+    K = DoubleLayerKernel(pde)
+    u = sum(qnodes(quad)) do source
+        return K(x, source) * weight(source)
+    end
+    return s * u + 0.5 < 0
+    # u < 0
+end
+isinside(x::Tuple, quad::Quadrature) = isinside(SVector(x), quad)

--- a/src/quadrature.jl
+++ b/src/quadrature.jl
@@ -11,6 +11,21 @@ struct QuadratureNode{N,T<:Real}
 end
 
 """
+    coords(q::QuadratureNode)
+
+Return the spatial coordinates of `q`.
+"""
+coords(q::QuadratureNode) = q.coords
+
+# useful for using either a quadrature node or a just a simple point in
+# `IntegralOperators`.
+coords(x::Union{SVector,NTuple}) = SVector(x)
+
+
+normal(q::QuadratureNode) = q.normal
+weight(q::QuadratureNode) = q.weight
+
+"""
     struct Quadrature{N,T} <: AbstractVector{QuadratureNode{N,T}}
 
 A collection of [`QuadratureNode`](@ref)s used to integrate over an
@@ -24,7 +39,7 @@ struct Quadrature{N,T} <: AbstractVector{QuadratureNode{N,T}}
 end
 
 # AbstractArray interface
-Base.size(quad::Quadrature) = (length(quad.qnodes),)
+Base.size(quad::Quadrature) = size(quad.qnodes)
 Base.getindex(quad::Quadrature, i) = quad.qnodes[i]
 
 ambient_dimension(quad::Quadrature) = ambient_dimension(quad.mesh)


### PR DESCRIPTION
This PR implements the foundations for specific `Nystrom` methods. The following structures are to be implemented:

- [x] `NystromDensity`
- [x] `IntegralPotential`
- [x] `IntegralOperator`