### PR TITLE
Modify `API` to require target location for `dim` methods

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -20,7 +20,7 @@ ON_CI && (draft = false) # always full build on CI
 
 function insert_setup(content)
     ON_CI || return content
-    replace(content, "#nb ## __NOTEBOOK_SETUP__" => SETUP)
+    return replace(content, "#nb ## __NOTEBOOK_SETUP__" => SETUP)
 end
 
 # Generate examples using Literate
@@ -32,7 +32,12 @@ for example in ["helmholtz_scattering.jl", "poisson.jl"]
         src = joinpath(examples_dir, example)
         Literate.markdown(src, generated_dir; mdstrings = true)
         # if on CI, also generate the notebook
-        ON_CI && Literate.notebook(src, generated_dir; mdstrings = true, preprocess = insert_setup)
+        ON_CI && Literate.notebook(
+            src,
+            generated_dir;
+            mdstrings = true,
+            preprocess = insert_setup,
+        )
     end
 end
 

--- a/docs/src/examples/helmholtz_scattering.jl
+++ b/docs/src/examples/helmholtz_scattering.jl
@@ -147,6 +147,7 @@ gmsh_circle(; meshsize, order = gorder, name)
 # We can now import the file and parse the mesh and domain information into
 # `Inti.jl` using the [`import_mesh_from_gmsh_file`](@ref Inti.import_mesh_from_gmsh_file) function:
 
+Inti.clear_entities!() # empty the entity cache
 Ω, msh = Inti.import_mesh_from_gmsh_file(name; dim = 2)
 @show Ω
 #-
@@ -198,7 +199,7 @@ S, D = Inti.single_double_layer(;
     target = Q,
     source = Q,
     compression = (method = :none,),
-    correction = (method = :dim, maxdist = 5 * meshsize, target_location = :on),
+    correction = (method = :dim, maxdist = 5 * meshsize),
 )
 
 # There are two well-known difficulties related to the discretization of
@@ -391,7 +392,7 @@ S, D = Inti.single_double_layer(;
     target = Q,
     source = Q,
     compression = (method = :hmatrix, tol = 1e-6),
-    correction = (method = :dim, target_location = :on),
+    correction = (method = :dim,),
 )
 
 # Here is how much memory it would take to store the dense representation of

--- a/src/Inti.jl
+++ b/src/Inti.jl
@@ -1,3 +1,8 @@
+"""
+    module Inti
+
+Library for solving integral equations using Nyström methods.
+"""
 module Inti
 
 const PROJECT_ROOT = pkgdir(Inti)

--- a/src/api.jl
+++ b/src/api.jl
@@ -1,4 +1,19 @@
 """
+    const COMPRESSION_METHODS = [:none, :hmatrix, :fmm]
+
+Available compression methods for the dense linear operators in [`Inti`](@ref).
+"""
+const COMPRESSION_METHODS = [:none, :hmatrix, :fmm]
+
+"""
+    const CORRECTION_METHODS = [:none, :dim, :hcubature]
+
+Available correction methods for the singular and nearly-singular integrals in
+[`Inti`](@ref).
+"""
+const CORRECTION_METHODS = [:none, :dim, :hcubature]
+
+"""
     single_double_layer(; pde, target, source::Quadrature, compression,
     correction, derivative = false)
 
@@ -17,11 +32,12 @@ The `compression` argument is a named tuple with a `method` field followed by
 method-specific fields. It specifies how the dense linear operators should be
 compressed. The available options are:
 
-  - `(method = :none, )`: no compression is performed, the resulting matrices are dense.
+  - `(method = :none, )`: no compression is performed, the resulting matrices
+    are dense.
   - `(method =:hmatrix, tol)`: the resulting operators are compressed using
-    hierarchical matrices with an absolute tolerance `tol` (defaults to  `1e-8`).
-  - `(method = :fmm, tol)`: the resulting operators are compressed using the fast multipole method
-    with an absolute tolerance `tol` (defaults to `1e-8`).
+    hierarchical matrices with an absolute tolerance `tol` (defaults to `1e-8`).
+  - `(method = :fmm, tol)`: the resulting operators are compressed using the
+    fast multipole method with an absolute tolerance `tol` (defaults to `1e-8`).
 
 ## Correction
 
@@ -32,10 +48,12 @@ integrals should be computed. The available options are:
   - `(method = :none, )`: no correction is performed. This is not recommented,
     as the resulting approximation will be inaccurate if the source and target
     are not sufficiently far apart.
-  - `(method = :dim, maxdist)`: use the density interpolation method to compute
-    the correction. `maxdist` specifies the distance between
-    source and target points above which no correction is performed
-    (defaults to `Inf`).
+  - `(method = :dim, maxdist, target_location)`: use the density interpolation
+    method to compute the correction. `maxdist` specifies the distance between
+    source and target points above which no correction is performed (defaults to
+    `Inf`). `target_location` should be either `:inside`, `:outside`, or `:on`,
+    and specifies where the `target`` points lie relative to the to the `source`
+    curve/surface (which is assumed to be closed).
 """
 function single_double_layer(;
     pde,
@@ -69,6 +87,8 @@ function single_double_layer(;
     if correction.method == :none
         return Smat, Dmat # shortcircuit case without correction
     elseif correction.method == :dim
+        μ = _green_multiplier(correction.target_location)
+        green_multiplier = fill(μ, length(target))
         dict_near = etype_to_nearest_points(target, source; correction.maxdist)
         # If target != source then we want to filter the near-field points and construct auxiliary
         # IntegralOperator with targets limited to those that will be corrected.
@@ -108,7 +128,8 @@ function single_double_layer(;
                 source,
                 Sop_dim_mat,
                 Dop_dim_mat;
-                maxdist = correction.maxdist,
+                green_multiplier,
+                correction.maxdist,
                 derivative,
                 filter_target_params,
             )
@@ -119,7 +140,8 @@ function single_double_layer(;
                 source,
                 Smat,
                 Dmat;
-                maxdist = correction.maxdist,
+                green_multiplier,
+                correction.maxdist,
                 derivative,
             )
         end
@@ -204,7 +226,8 @@ function volume_potential(; pde, target, source::Quadrature, compression, correc
     if correction.method == :none
         return Vmat
     elseif correction.method == :dim
-        maxdist = correction.maxdist
+        μ = _green_multiplier(correction.target_location)
+        green_multiplier = fill(μ, length(target))
         if haskey(correction, :boundary)
             boundary = correction.boundary
         elseif source.mesh isa SubMesh # attempt to find the boundary in the parent mesh
@@ -240,7 +263,8 @@ function volume_potential(; pde, target, source::Quadrature, compression, correc
             S,
             D,
             Vmat;
-            maxdist,
+            green_multiplier,
+            correction.maxdist,
             interpolation_order,
         )
     else
@@ -248,7 +272,14 @@ function volume_potential(; pde, target, source::Quadrature, compression, correc
     end
     # add correction
     if compression.method ∈ (:hmatrix, :none)
-        V = axpy!(true, δV, Vmat)
+        # TODO: in the hmatrix case, we may want to add the correction directly
+        # to the HMatrix so that a direct solver can be later used
+        V = LinearMap(Vmat) + LinearMap(δV)
+        # if target === source
+        #     V = axpy!(true, δV, Vmat)
+        # else
+        #     V = LinearMap(Vmat) + LinearMap(δV)
+        # end
     elseif compression.method == :fmm
         V = Vmat + LinearMap(δV)
     end

--- a/src/nystrom.jl
+++ b/src/nystrom.jl
@@ -156,6 +156,26 @@ end
 _green_multiplier(x::Tuple, Q::Quadrature) = _green_multiplier(SVector(x), Q)
 _green_multiplier(x::QuadratureNode, Q::Quadrature) = _green_multiplier(coords(x), Q)
 
+"""
+    _green_multiplier(s::Symbol)
+
+Return `-1.0` if `s == :inside`, `0.0` if `s == :outside`, and `-0.5` if `s ==
+:on`; otherwise, throw an error. The orientation is relative to the normal of
+the bounding curve/surface.
+"""
+function _green_multiplier(s::Symbol)
+    # assume an exterior normal orientation and a smooth surface
+    if s == :inside
+        return -1.0
+    elseif s == :outside
+        return 0.0
+    elseif s == :on
+        return -0.5
+    else
+        return error("Unknown target location $s. Expected :inside, :outside, or :on")
+    end
+end
+
 # Applying Laplace's double-layer to a constant will yield either 1 or -1,
 # depending on whether the target point is inside or outside the obstacle.
 # Assumes `quad` is the quadrature of a closed curve/surface

--- a/src/quadrature.jl
+++ b/src/quadrature.jl
@@ -216,7 +216,7 @@ function etype_to_nearest_points(X, Y::Quadrature; maxdist = Inf)
     return dict
 end
 
-function _etype_to_nearest_points(X, Y::Quadrature, maxdist = Inf)
+function _etype_to_nearest_points(X, Y::Quadrature, maxdist)
     y = [coords(q) for q in Y]
     kdtree = KDTree(y)
     dict = Dict(j => Int[] for j in 1:length(y))
@@ -252,7 +252,6 @@ function quadrature_to_node_vals(Q::Quadrature, qvals::AbstractVector)
     ivals = zeros(eltype(qvals), length(inodes))
     areas = zeros(length(inodes)) # area of neighboring triangles
     for (E, mat) in etype2mat(msh)
-        @info E
         qrule = Q.etype2qrule[E]
         V = mapreduce(lagrange_basis(E), hcat, qcoords(qrule)) |> Matrix
         ni, nel = size(mat) # number of interpolation nodes by number of elements

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -221,13 +221,20 @@ function _normalize_compression(compression)
 end
 
 function _normalize_correction(correction)
-    methods = (:dim, :none)
+    methods = (:dim, :hcubature, :none)
     # check that method is valid
-    correction.method ∈ (:dim, :none) ||
+    correction.method ∈ methods ||
         error("Unknown correction.method $(correction.method). Available options: $methods")
-    #
+    # set default values if absent
     if correction.method == :dim
-        correction = merge((maxdist = Inf, interpolation_order = nothing), correction)
+        haskey(correction, :target_location) ||
+            error("missing target_location field in correction")
+        haskey(correction, :maxdist) ||
+            @warn("missing maxdist field in correction: setting to Inf")
+        correction = merge(
+            (maxdist = Inf, interpolation_order = nothing, center = nothing),
+            correction,
+        )
     end
     return correction
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -209,7 +209,7 @@ end
 const Point2D = SVector{2,Float64}
 const Point3D = SVector{3,Float64}
 
-function _normalize_compression(compression)
+function _normalize_compression(compression, target, source)
     methods = (:hmatrix, :fmm, :none)
     # check that method is valid
     compression.method ∈ (:hmatrix, :fmm, :none) || error(
@@ -220,14 +220,19 @@ function _normalize_compression(compression)
     return compression
 end
 
-function _normalize_correction(correction)
+function _normalize_correction(correction, target, source)
     methods = (:dim, :hcubature, :none)
     # check that method is valid
     correction.method ∈ methods ||
         error("Unknown correction.method $(correction.method). Available options: $methods")
     # set default values if absent
     if correction.method == :dim
+        haskey(correction, :target_location) &&
+            target === source &&
+            @warn("ignoring target_location field in correction since target === source")
+        # target location required unless target === source
         haskey(correction, :target_location) ||
+            target === source ||
             error("missing target_location field in correction")
         haskey(correction, :maxdist) ||
             @warn("missing maxdist field in correction: setting to Inf")

--- a/src/vdim.jl
+++ b/src/vdim.jl
@@ -1,3 +1,30 @@
+"""
+    vdim_correction(pde,X,Y,Y_boundary,S,D,V; green_multiplier, kwargs...)
+
+Compute a correction to the volume potential `V : Y → X` such that `V + δV` is a
+more accurate approximation of the underlying volume potential operator. The
+correction is computed using the (volume) density interpolation method.
+
+This function requires a `pde::AbstractPDE`, a target set `X`, a source
+quadrature `Y`, a boundary quadrature `Y_boundary`, approximations `S :
+Y_boundary -> X` and `D : Y_boundary -> X` to the single- and double-layer
+potentials (correctly handling nearly-singular integrals), and a naive
+approximation of the volume potential `V`. The `green_multiplier` is a vector of
+the same length as `X` storing the value of `μ(x)` for `x ∈ X` in the Green
+identity (see [`_green_multiplier`](@ref)).
+
+## Optional `kwargs`:
+
+- `interpolation_order`: the order of the polynomial interpolation. By default,
+  the maximum order of the quadrature rules is used.
+- `maxdist`: distance beyond which interactions are considered sufficiently far
+  so that no correction is needed. This is used to determine a threshold for
+  nearly-singular corrections.
+- `center`: the center of the basis functions. By default, the basis functions
+  are centered at the origin.
+- `shift`: a boolean indicating whether the basis functions should be shifted
+  and rescaled to each element.
+"""
 function vdim_correction(
     pde,
     target,
@@ -6,9 +33,8 @@ function vdim_correction(
     Sop,
     Dop,
     Vop;
-    interpolation_order = nothing,
-    derivative = false,
     green_multiplier::Vector{<:Real},
+    interpolation_order = nothing,
     maxdist = Inf,
     center = nothing,
     shift::Val{SHIFT} = Val(false),

--- a/src/vdim.jl
+++ b/src/vdim.jl
@@ -1,6 +1,3 @@
-"""
-    vdim_correction(pde,X,Y,Γ,S,D,V[;interpolation_order, multiplier])
-"""
 function vdim_correction(
     pde,
     target,
@@ -11,47 +8,43 @@ function vdim_correction(
     Vop;
     interpolation_order = nothing,
     derivative = false,
-    green_multiplier = nothing,
+    green_multiplier::Vector{<:Real},
     maxdist = Inf,
+    center = nothing,
     shift::Val{SHIFT} = Val(false),
 ) where {SHIFT}
-    max_cond = -Inf
-    max_coefs = -Inf
+    # variables for debugging the condition properties of the method
+    vander_cond = vander_norm = rhs_norm = res_norm = shift_norm = -Inf
     T = eltype(Vop)
     @assert eltype(Dop) == eltype(Sop) == T "eltype of Sop, Dop, and Vop must match"
     # figure out if we are dealing with a scalar or vector PDE
-    σ = if T <: Number
-        1
-    else
-        @assert allequal(size(T))
-        size(T, 1)
-    end
+    m, n = length(target), length(source)
     N = ambient_dimension(pde)
     @assert ambient_dimension(source) == N "vdim only works for volume potentials"
     m, n = length(target), length(source)
-    # maximum number of quadrature nodes per element
-    qmax = sum(size(mat, 1) for mat in values(source.etype2qtags))
-    # TODO: relate order to qmax?
+    # a reasonable interpolation_order if not provided
     isnothing(interpolation_order) &&
         (interpolation_order = maximum(order, values(source.etype2qrule)))
-    p, P, γ₁P = polynomial_solutions_vdim(pde, interpolation_order)
-    multiindices = [MultiIndex(first(keys(f.order2coeff))) for f in p]
-    μ = if isnothing(green_multiplier)
-        μ_ = _green_multiplier(target[1], boundary)
-        # snap to the nearest "generic" value of μ
-        argmin(x -> norm(μ_ - x), (-1, -0.5, 0, 0.5, 1))
-    elseif isscalar(green_multiplier)
-        green_multiplier
-    else
-        error("green_multiplier must be a scalar")
-    end
+    # by default basis centered at origin
+    center = isnothing(center) ? zero(SVector{N,Float64}) : center
+    p, P, γ₁P, multiindices = polynomial_solutions_vdim(pde, interpolation_order, center)
     dict_near = etype_to_nearest_points(target, source; maxdist)
-    R = _vdim_auxiliary_quantities(p, P, γ₁P, target, source, boundary, μ, Sop, Dop, Vop)
+    R = _vdim_auxiliary_quantities(
+        p,
+        P,
+        γ₁P,
+        target,
+        source,
+        boundary,
+        green_multiplier,
+        Sop,
+        Dop,
+        Vop,
+    )
     # compute sparse correction
     Is = Int[]
     Js = Int[]
     Vs = eltype(Vop)[]
-    nbasis = length(p)
     for (E, qtags) in source.etype2qtags
         els = elements(source.mesh, E)
         near_list = dict_near[E]
@@ -64,19 +57,30 @@ function vdim_correction(
             # compute translation and scaling
             c, r = translation_and_scaling(els[n])
             if SHIFT
-                L̃ = [f(q.coords) for f in p, q in view(source, jglob)]
-                @debug (max_cond = max(max_cond, cond(L̃))) maxlog = 0
-                S = change_of_basis(multiindices, c, r)
+                iszero(center) || error("SHIFT is not implemented for non-zero center")
+                L̃ = [f((q.coords - c) / r) for f in p, q in view(source, jglob)]
+                S = change_of_basis(multiindices, p, c, r)
                 F = lu(L̃)
+                @debug (vander_cond = max(vander_cond, cond(L̃))) maxlog = 0
+                @debug (shift_norm = max(shift_norm, norm(S))) maxlog = 0
+                @debug (vander_norm = max(vander_norm, norm(L̃))) maxlog = 0
             else
-                L = [f((q.coords - c) / r) for f in p, q in view(source, jglob)]
-                @debug (max_cond = max(max_cond, cond(L))) maxlog = 0
+                L = [f(q.coords) for f in p, q in view(source, jglob)]
                 F = lu(L)
+                @debug (vander_cond = max(vander_cond, cond(L))) maxlog = 0
+                @debug (shift_norm = max(shift_norm, 1)) maxlog = 0
+                @debug (vander_norm = max(vander_norm, norm(L))) maxlog = 0
             end
             # correct each target near the current element
             for i in near_list[n]
-                wei = SHIFT ? F \ (S * R[i, :]) : F \ R[i, :] # weights for the current element and target i
-                max_coefs = max(max_coefs, norm(wei, Inf))
+                b = @views R[i, :]
+                wei = SHIFT ? F \ (S * b) : F \ b # weights for the current element and target i
+                rhs_norm = max(rhs_norm, norm(b))
+                res_norm = if SHIFT
+                    max(res_norm, norm(L̃ * wei - S * b))
+                else
+                    max(res_norm, norm(L * wei - b))
+                end
                 for k in 1:nq
                     push!(Is, i)
                     push!(Js, jglob[k])
@@ -85,13 +89,18 @@ function vdim_correction(
             end
         end
     end
-    @debug "maximum condition encountered: $max_cond"
-    @debug "maximum norm of coefficiets:   $max_coefs"
+    @debug """Condition properties of vdim correction:
+    |-- max interp. matrix condition: $vander_cond
+    |-- max norm of source term:      $rhs_norm
+    |-- max residual error:           $res_norm
+    |-- max interp. matrix norm :     $vander_norm
+    |-- max shift norm :              $shift_norm
+    """
     δV = sparse(Is, Js, Vs, m, n)
     return δV
 end
 
-function change_of_basis(multiindices, c, r)
+function change_of_basis(multiindices, p, c, r)
     nbasis = length(multiindices)
     P = zeros(nbasis, nbasis)
     for i in 1:nbasis
@@ -99,7 +108,11 @@ function change_of_basis(multiindices, c, r)
         for j in 1:nbasis
             β = multiindices[j]
             β ≤ α || continue
-            P[i, j] = prod((-c) .^ ((α - β).indices)) / r^abs(α) / factorial(α - β)
+            # P[i, j] = prod((-c) .^ ((α - β).indices)) / r^abs(α) / factorial(α
+            # - β)
+            γ = α - β
+            p_γ = p[findfirst(x -> x == γ, multiindices)] # p_{\alpha - \beta}
+            P[i, j] = p_γ(-c) / r^abs(α)
         end
     end
     return P
@@ -208,7 +221,7 @@ function _vdim_auxiliary_quantities(
     X,
     Y::Quadrature,
     Γ::Quadrature,
-    σ,
+    μ,
     Sop,
     Dop,
     Vop,
@@ -225,22 +238,47 @@ function _vdim_auxiliary_quantities(
         @views mul!(Θ[:, n], Dop, γ₀B[:, n], -1, 1)
         @views mul!(Θ[:, n], Vop, b[:, n], -1, 1)
         for i in 1:num_targets
-            Θ[i, n] += σ * P[n](X[i])
+            Θ[i, n] += μ[i] * P[n](X[i])
         end
     end
     return Θ
 end
 
 """
-    polynomial_solutions_vdim(pde, order)
+    vdim_mesh_center(msh)
+
+Point `x` which minimizes ∑ (x-xⱼ)²/r²ⱼ, where xⱼ and rⱼ are the circumcenter
+and circumradius of the elements of `msh`, respectively.
+"""
+function vdim_mesh_center(msh::AbstractMesh)
+    N = ambient_dimension(msh)
+    M = 0.0
+    xc = zero(SVector{N,Float64})
+    for E in element_types(msh)
+        for el in elements(msh, E)
+            c, r = translation_and_scaling(el)
+            # w = 1/r^2
+            w = 1
+            M += w
+            xc += c * w
+        end
+    end
+    return xc / M
+end
+
+"""
+    polynomial_solutions_vdim(pde, order[, center])
 
 For every monomial term `pₙ` of degree `order`, compute a polynomial `Pₙ` such
 that `ℒ[Pₙ] = pₙ`, where `ℒ` is the differential operator associated with `pde`.
 This function returns `{pₙ,Pₙ,γ₁Pₙ}`, where `γ₁Pₙ` is the generalized Neumann
 trace of `Pₙ`.
+
+Passing a point `center` will shift the monomials and solutions accordingly.
 """
-function polynomial_solutions_vdim(pde::AbstractPDE, order::Integer)
+function polynomial_solutions_vdim(pde::AbstractPDE, order::Integer, center = nothing)
     N = ambient_dimension(pde)
+    center = isnothing(center) ? zero(SVector{N,Float64}) : center
     # create empty arrays to store the monomials, solutions, and traces. For the
     # neumann trace, we try to infer the concrete return type instead of simply
     # having a vector of `Function`.
@@ -248,6 +286,7 @@ function polynomial_solutions_vdim(pde::AbstractPDE, order::Integer)
     dirchlet_traces = Vector{ElementaryPDESolutions.Polynomial{N,Float64}}()
     T = return_type(neumann_trace, typeof(pde), eltype(dirchlet_traces))
     neumann_traces = Vector{T}()
+    multiindices = Vector{MultiIndex{N}}()
     # iterate over N-tuples going from 0 to order
     for I in Iterators.product(ntuple(i -> 0:order, N)...)
         sum(I) > order && continue
@@ -256,11 +295,22 @@ function polynomial_solutions_vdim(pde::AbstractPDE, order::Integer)
         p   = ElementaryPDESolutions.Polynomial(I => 1 / factorial(MultiIndex(I)))
         P   = polynomial_solution(pde, p)
         γ₁P = neumann_trace(pde, P)
+        push!(multiindices, MultiIndex(I))
         push!(monomials, p)
         push!(dirchlet_traces, P)
         push!(neumann_traces, γ₁P)
     end
-    return monomials, dirchlet_traces, neumann_traces
+    monomial_shift = map(monomials) do f
+        return (q) -> f(coords(q) - center)
+    end
+    dirchlet_shift = map(dirchlet_traces) do f
+        return (q) -> f(coords(q) - center)
+    end
+    neumann_shift = map(neumann_traces) do f
+        return (q) -> f((coords = q.coords - center, normal = q.normal))
+    end
+    return monomial_shift, dirchlet_shift, neumann_shift, multiindices
+    # return monomials, dirchlet_traces, neumann_traces, multiindices
 end
 
 # dispatch to the correct solver in ElementaryPDESolutions
@@ -284,7 +334,7 @@ end
 
 function _normal_derivative(P::ElementaryPDESolutions.Polynomial{N,T}) where {N,T}
     ∇P = ElementaryPDESolutions.gradient(P)
-    return (q) -> dot(normal(q), ∇P(q))
+    return (q) -> dot(normal(q), ∇P(coords(q)))
 end
 
 function (∇P::NTuple{N,<:ElementaryPDESolutions.Polynomial})(x) where {N}

--- a/test/convergence/dim_convergence.jl
+++ b/test/convergence/dim_convergence.jl
@@ -71,7 +71,7 @@ for h in hh
         target = Q,
         source = Q,
         compression = (method = :none,),
-        correction = (method = :dim,),
+        correction = (method = :dim, target_location = :on),
     )
     e0 = norm(S0 * γ₁u - D0 * γ₀u - σ * γ₀u, Inf) / γ₀u_norm
     e1 = norm(S1 * γ₁u - D1 * γ₀u - σ * γ₀u, Inf) / γ₀u_norm

--- a/test/dim_test.jl
+++ b/test/dim_test.jl
@@ -51,7 +51,7 @@ for N in (2, 3)
                     target      = quad,
                     source      = quad,
                     compression = (method = :none,),
-                    correction  = (method = :dim, target_location = :on),
+                    correction  = (method = :dim,),
                 )
                 e1 = norm(Sdim * γ₁u - Ddim * γ₀u - σ * γ₀u, Inf) / γ₀u_norm
                 @testset "Single/double layer $(string(pde))" begin
@@ -71,7 +71,7 @@ for N in (2, 3)
                     target = quad,
                     source = quad,
                     compression = (method = :none,),
-                    correction = (method = :dim, target_location = :on),
+                    correction = (method = :dim,),
                 )
                 e1 = norm(Kdim * γ₁u - Hdim * γ₀u - σ * γ₁u, Inf)
                 @testset "Adjoint double-layer/hypersingular $(string(pde))" begin

--- a/test/dim_test.jl
+++ b/test/dim_test.jl
@@ -51,7 +51,7 @@ for N in (2, 3)
                     target      = quad,
                     source      = quad,
                     compression = (method = :none,),
-                    correction  = (method = :dim,),
+                    correction  = (method = :dim, target_location = :on),
                 )
                 e1 = norm(Sdim * γ₁u - Ddim * γ₀u - σ * γ₀u, Inf) / γ₀u_norm
                 @testset "Single/double layer $(string(pde))" begin
@@ -71,7 +71,7 @@ for N in (2, 3)
                     target = quad,
                     source = quad,
                     compression = (method = :none,),
-                    correction = (method = :dim,),
+                    correction = (method = :dim, target_location = :on),
                 )
                 e1 = norm(Kdim * γ₁u - Hdim * γ₀u - σ * γ₁u, Inf)
                 @testset "Adjoint double-layer/hypersingular $(string(pde))" begin

--- a/test/quadrature_test.jl
+++ b/test/quadrature_test.jl
@@ -65,6 +65,7 @@ using Inti
             Inti.clear_entities!()
             gmsh.initialize()
             gmsh.option.setNumber("General.Verbosity", 2)
+            gmsh.option.setNumber("Mesh.MeshSizeMax", 0.1)
             Inti.clear_entities!()
             gmsh.model.occ.addDisk(0, 0, 0, rx, ry)
             gmsh.model.occ.synchronize()


### PR DESCRIPTION
This *PR* changes the *API* of the *DIM* correction to require a `target_location` keyword. Before, this was inferred from the value of $\int_\Gamma G(x,y) ds_y$, where $G$ is the fundamental solution of Laplace's equation, and $x$ was simply the first point in `target`. From Green identity, the exact value of the integral above is either 0, 1, or 1/2, depending on the location of $x$. 

I think it is better to put the burden on the user for this one, since inferring whether the targets are inside, outside, or on the surface $\Gamma$ can be tricky. @tanderson92 Thoughts?

