### PR TITLE
Update docs on integral operators and compression methods

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
+DocumenterInterLinks = "d12716ef-a0f6-4df4-a9f1-a5a34e75c656"
 FMM2D = "2d63477d-9690-4b75-bcc1-c3461d43fecc"
 FMM3D = "1e13804c-f9b7-11ea-0ef0-29f3b1745df8"
 FMMLIB2D = "1a804d9e-d798-534b-a6a9-4525c36f0718"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -18,7 +18,7 @@ links = InterLinks(
 
 bib = CitationBibliography(joinpath(@__DIR__, "src", "refs.bib"); style = :numeric)
 
-draft = true
+draft = false
 
 const ON_CI = get(ENV, "CI", "false") == "true"
 const GIT_HEAD = chomp(read(`git rev-parse HEAD`, String))

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,7 @@
 using Inti
 using Documenter
 using DocumenterCitations
+using DocumenterInterLinks
 using Literate
 # packages needed for extensions
 using Gmsh
@@ -10,9 +11,14 @@ using GLMakie
 using FMM2D
 using FMM3D
 
+links = InterLinks(
+    "Meshes" => "https://juliageometry.github.io/MeshesDocs/dev/objects.inv",
+    "HMatrices" => "https://integralequations.github.io/HMatrices.jl/stable/objects.inv",
+)
+
 bib = CitationBibliography(joinpath(@__DIR__, "src", "refs.bib"); style = :numeric)
 
-draft = false
+draft = true
 
 const ON_CI = get(ENV, "CI", "false") == "true"
 const GIT_HEAD = chomp(read(`git rev-parse HEAD`, String))
@@ -99,7 +105,7 @@ makedocs(;
     pagesonly = true,
     checkdocs = :none,
     draft,
-    plugins = [bib],
+    plugins = [bib, links],
 )
 
 deploydocs(;

--- a/docs/src/examples/helmholtz_scattering.jl
+++ b/docs/src/examples/helmholtz_scattering.jl
@@ -545,7 +545,7 @@ u_eval_msh = ui_eval_msh + us_eval_msh
 nothing #hide
 
 # Finalize, we use
-# [`viz`](https://juliageometry.github.io/MeshesDocs/stable/visualization.html#Meshes.viz)
+# [`Meshes.viz`](@extref)
 # to visualize the scattered field:
 
 using Meshes

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -80,9 +80,9 @@ problem consists of the following steps:
 - **Mesh**: Create a mesh to approximate the geometry. The mesh is used to
   define a quadrature and discretize the boundary integral equation.
 - **Solver**: With a mesh and an accompanying quadrature, Inti.jl's routines
- provide ways to assemble and solve the system of equations arising from the
- discretization of the integral operators. The core of the library lies in this
- step.
+  provide ways to assemble and solve the system of equations arising from the
+  discretization of the integral operators. The core of the library lies in this
+  step.
 - **Visualization**: Visualize the solution using a plotting library such as
   Makie.jl, or export it to a file for further analysis.
 

--- a/docs/src/refs.bib
+++ b/docs/src/refs.bib
@@ -31,3 +31,40 @@
   year      = {2013},
   publisher = {SIAM}
 }
+
+@book{bebendorf2008hierarchical,
+  title     = {Hierarchical matrices},
+  author    = {Bebendorf, Mario},
+  year      = {2008},
+  publisher = {Springer}
+}
+
+@book{hackbusch2015hierarchical,
+  title     = {Hierarchical matrices: algorithms and analysis},
+  author    = {Hackbusch, Wolfgang and others},
+  volume    = {49},
+  year      = {2015},
+  publisher = {Springer}
+}
+
+@article{rokhlin1985rapid,
+  title     = {Rapid solution of integral equations of classical potential theory},
+  author    = {Rokhlin, Vladimir},
+  journal   = {Journal of computational physics},
+  volume    = {60},
+  number    = {2},
+  pages     = {187--207},
+  year      = {1985},
+  publisher = {Elsevier}
+}
+
+@article{greengard1987fast,
+  title     = {A fast algorithm for particle simulations},
+  author    = {Greengard, Leslie and Rokhlin, Vladimir},
+  journal   = {Journal of computational physics},
+  volume    = {73},
+  number    = {2},
+  pages     = {325--348},
+  year      = {1987},
+  publisher = {Elsevier}
+}

--- a/docs/src/tutorials/compression_methods.md
+++ b/docs/src/tutorials/compression_methods.md
@@ -5,19 +5,51 @@ CurrentModule = Inti
 ```
 
 Inti.jl wraps several external libraries providing acceleration routines for
-integral operators. All compression methods in Inti.jl take an
-`IntegralOperator` and return a new object that represents a compressed version
+integral operators. In general, acceleration routines have the signature
+`assemble_*(iop, args...; kwargs...)`, and take an [`IntegralOperator`](@ref) as
+a first argument. They return a new object that represents a compressed version
 of the operator. The following methods are available:
 
-- [`assemble_matrix`](@ref) - Assemble the operator as a dense matrix. Not
-  really a compression method, but useful for debugging and small problems.
-- [`assemble_hmatrix`](@ref) - Assemble the operator as a hierarchical matrix.
-- [`assemble_fmm`](@ref) - Assemble the operator using the fast multipole method.
+- [`assemble_matrix`](@ref): create a dense `Matrix` representation of the
+  integral operator. Not really a compression method, but useful for debugging
+  and small problems.
+- [`assemble_hmatrix`](@ref): assemble a hierarchical matrix representation of
+  the operator using the
+  [`HMatrices`](https://github.com/IntegralEquations/HMatrices.jl) library.
+- [`assemble_fmm`](@ref): return a `LinearMap` object that represents the
+  operator using the fast multipole method. This method is powered by the
+  [`FMM2D`](https://github.com/flatironinstitute/fmm2d/) and
+  [`FMM3D`](https://fmm3d.readthedocs.io) libraries, and is only available for
+  certain kernels.
 
-All of the compression methods take an `IntegralOperator` and return a new
-object that represents a compressed version of the operator. Not all methods
-work with all operators; the next sections provide more details on their usage
-and limitations.
+!!! warning "Singular kernels"
+    Acceleration methods do not correct for singular or nearly-singular
+    interactions. When the underlying kernel is singular, a *correction* is
+    usually necessary in order to obtain accurate results (see the [section on
+    correction methods](@ref "Correction mehods") for more details).
+  
+To illustrate the use of compression methods, we will use the following problem
+as an example. Note that for such a small problem, compression methods are not
+likely not necessary, but they are useful for larger problems.
+
+```@example compression
+using Inti
+using LinearAlgebra
+# define the quadrature
+geo = Inti.ball()
+Ω = Inti.Domain(geo)
+Γ = Inti.boundary(Ω)
+Q = Inti.Quadrature(Γ; meshsize = 0.4, qorder = 5)
+# create the operator
+pde = Inti.Helmholtz(; dim = 3, k = 2π)
+K = Inti.SingleLayerKernel(pde)
+Sop = Inti.IntegralOperator(K, Q, Q)
+x = rand(eltype(Sop), length(Q))
+rtol = 1e-8
+nothing # hide
+```
+
+In what follows we compress `Sop` using the different methods available.
 
 ## Dense matrix
 
@@ -25,14 +57,86 @@ and limitations.
 assemble_matrix
 ```
 
+Typically used for small problems, the dense matrix representation converts the
+`IntegralOperator` into a `Matrix` object. The underlying type of the `Matrix`
+is determined by the `eltype` of the `IntegralOperator`, and depends on the
+inferred type of the kernel. Here is how `assemble_matrix` can be used:
+
+```@example compression
+Smat = Inti.assemble_matrix(Sop; threads=true)
+@assert Sop * x ≈ Smat * x # hide
+er = norm(Sop * x - Smat * x, Inf) / norm(Sop * x, Inf)
+println("Forward map error: $er")
+```
+
+Since the returned object is plain Julia `Matrix`, it can be used with any of
+the linear algebra routines available in Julia (e.g. `\`, `lu`, `qr`, `*`, etc.)
+
 ## Hierarchical matrix
 
 ```@docs; canonical = false
 assemble_hmatrix
 ```
 
+The hierarchical matrix representation is a compressed representation of the
+underlying operator; as such, it takes a tolerance parameter that determines the
+relative error of the compression. Here is an example of how to use the
+`assemble_hmatrix` method to compress the previous problem:
+
+```@example compression
+using HMatrices
+Shmat = Inti.assemble_hmatrix(Sop; rtol = 1e-8)
+er = norm(Smat * x - Shmat * x, Inf) / norm(Smat * x, Inf)
+@assert er < 10*rtol # hide
+println("Forward map error: $er")
+```
+
+Note that `HMatrices` are said to be *kernel-independent*, meaning that they
+efficiently compress a wide range of integral operators provided they satisfy a
+certain asymptotically smooth criterion (see e.g. [bebendorf2008hierarchical,
+hackbusch2015hierarchical](@cite)).
+
+The `HMatrix` object can be used to solve linear systems, both iteratively
+through e.g. GMRES, or directly using an `LU` factorization.
+
 ## Fast multipole method
 
 ```@docs; canonical = false
 assemble_fmm
 ```
+
+The fast multipole method (FMM) is an acceleration technique based on an
+analytic multipole expansion of the kernel in the integral operator
+[rokhlin1985rapid, greengard1987fast](@cite). It provides a very
+memory-efficient and fast way to evaluate certain types of integral operators.
+Here is how `assemble_fmm` can be used:
+
+```@example compression
+using FMM3D
+Sfmm = Inti.assemble_fmm(Sop; rtol = 1e-8)
+er = norm(Sop * x - Sfmm * x, Inf) / norm(Sop * x, Inf)
+@assert er < 10*rtol # hide
+println("Forward map error: $er")
+```
+
+## Tips on choosing a compression method
+
+The choice of compression method depends on the problem at hand, as well as on
+the available hardware. Here is a rough guide on how to choose a compression:
+
+1. For small problems (say less than 5k degrees of freedom), use the dense
+   matrix representation. It is the simplest and most straightforward method,
+   and does not require any additional packages. It is also the most accurate
+   since it does not introduce any approximation errors.
+2. If the integral operator is supported by the `assemble_fmm`, and if you can
+   afford an iterative solver, use it. The FMM is a very efficient method for
+   certain types of kernels, and can handle problems with up to a few million
+   degrees of freedom on a laptop.
+3. If the kernel is not supported by `assemble_fmm`, if iterative solvers are
+   not an option, or if you need to solve your system for many right-hand sides,
+   use the `assemble_hmatrix` method. It is a very general method that can
+   handle a wide range of kernels, and although assembling the `HMatrix` can be
+   time and memory consuming (the complexity is still log-linear in the DOFs for
+   many kernels of interest, but the constants can be large), the resulting
+   `HMatrix` object is very efficient to use. For example, the forward map is
+   usually significantly faster than the one obtained through `assemble_fmm`.

--- a/docs/src/tutorials/compression_methods.md
+++ b/docs/src/tutorials/compression_methods.md
@@ -3,3 +3,36 @@
 ```@meta
 CurrentModule = Inti
 ```
+
+Inti.jl wraps several external libraries providing acceleration routines for
+integral operators. All compression methods in Inti.jl take an
+`IntegralOperator` and return a new object that represents a compressed version
+of the operator. The following methods are available:
+
+- [`assemble_matrix`](@ref) - Assemble the operator as a dense matrix. Not
+  really a compression method, but useful for debugging and small problems.
+- [`assemble_hmatrix`](@ref) - Assemble the operator as a hierarchical matrix.
+- [`assemble_fmm`](@ref) - Assemble the operator using the fast multipole method.
+
+All of the compression methods take an `IntegralOperator` and return a new
+object that represents a compressed version of the operator. Not all methods
+work with all operators; the next sections provide more details on their usage
+and limitations.
+
+## Dense matrix
+
+```@docs; canonical = false
+assemble_matrix
+```
+
+## Hierarchical matrix
+
+```@docs; canonical = false
+assemble_hmatrix
+```
+
+## Fast multipole method
+
+```@docs; canonical = false
+assemble_fmm
+```

--- a/docs/src/tutorials/geo_and_meshes.md
+++ b/docs/src/tutorials/geo_and_meshes.md
@@ -85,7 +85,7 @@ viz!(Γ_msh; showsegments = true, alpha = 0.5)
 fig
 ```
 
-## `meshgen` and parametric entities
+## Parametric entities and `meshgen`
 
 In the previous section we saw an example of how to import a mesh from a file,
 and how to extract the entities from the mesh. For simple geometries for which
@@ -128,7 +128,7 @@ msh = Inti.meshgen(Γ; meshsize = 0.05)
 nothing # hide
 ```
 
-We can use the [`viz`](https://juliageometry.github.io/MeshesDocs/stable/visualization.html#Meshes.viz) function to visualize the mesh, and use
+We can use the [`Meshes.viz`](@extref) function to visualize the mesh, and use
 domains to index the mesh:
 
 ```@example geo-and-meshes
@@ -166,7 +166,7 @@ involved, Inti.jl provide a few helper functions to create simple shapes:
 ```@example geo-and-meshes
 bean = Inti.bean()
 torus = Inti.torus(; center = SVector(-3,0,0))
-Ω = bean ∪ torus
+Ω = Inti.Domain(bean,torus)
 Γ = Inti.boundary(Ω)
 msh = Inti.meshgen(Γ; meshsize = 0.1)
 fig = Figure(; size = (600,400))

--- a/docs/src/tutorials/geo_and_meshes.md
+++ b/docs/src/tutorials/geo_and_meshes.md
@@ -142,8 +142,8 @@ fig # hide
 
 ### Parametric surfaces
 
-Like parametric curves, parametric surfaces are defined by a function that a
-reference domain ``D \subset \mathbb{R}^2`` to a surface in 3D space. They can
+Like parametric curves, parametric surfaces are defined by a function that maps
+a reference domain ``D \subset \mathbb{R}^2`` to a surface in 3D space. They can
 be constructed using the [`parametric_surface`](@ref) function:
 
 ```@example geo-and-meshes

--- a/docs/src/tutorials/integral_operators.md
+++ b/docs/src/tutorials/integral_operators.md
@@ -6,35 +6,28 @@ CurrentModule = Inti
 
 !!! note "Important points covered in this tutorial"
     - Define layer potentials and the four integral operators of Calderón calculus
-    - Block operator construction and composition
-    - Volume integral operators
+    - Construct block operators
+    - Set up a custom kernel
 
 A central piece of integral equation methods is the efficient and accurate
 computation of integral operators. In the first part of this tutorial we will
 cover how to assemble and manipulate the four integral operators of Calderón
 calculus, namely the single-layer, double-layer, hypersingular, and adjoint
 operators [nedelec2001acoustic, colton2013integral](@cite), for some predefined
-kernels in Inti.jl. In the second part we will show how to extend the
-package to handle custom kernels.
+kernels in Inti.jl. In the second part we will show how to extend the package to
+handle custom kernels.
 
 ## Predefined kernels and integral operators
 
 To simplify the construction of integral operators for some commonly used PDEs,
-Inti.jl defines a few [`AbstractPDE`](@ref)s types:
+Inti.jl defines a few [`AbstractPDE`](@ref)s types. For each of these PDEs, the
+package provides a [`SingleLayerKernel`](@ref), [`DoubleLayerKernel`](@ref),
+[`HyperSingularKernel`](@ref), and [`AdjointDoubleLayerKernel`](@ref) that can
+be used to construct the corresponding kernel functions, e.g.:
 
 ```@example integral_operators
 using Inti, StaticArrays, LinearAlgebra
-using InteractiveUtils: subtypes # hide
-subtypes(Inti.AbstractPDE)
-```
-
-For each of these PDEs, the package provides a [`SingleLayerKernel`](@ref),
-[`DoubleLayerKernel`](@ref), [`HyperSingularKernel`](@ref), and
-[`AdjointDoubleLayerKernel`](@ref) that can be used to construct the corresponding kernel
-functions, e.g.:
-
-```@example integral_operators
-pde = Inti.Helmholtz(; dim = 2, k = 1.2)
+pde = Inti.Helmholtz(; dim = 2, k = 2π)
 G   = Inti.SingleLayerKernel(pde)
 ```
 
@@ -125,13 +118,15 @@ Sfmm
 ```
 
 The `FunctionMap` computes a matrix-vector by performing a function call to the
-`FMM2D` library. The `WrappedMap` accounts for a sparse matrix used to account
+`FMM2D` library. The `WrappedMap` accounts for a sparse matrix used to correct
 for singular and nearly singular interactions. These two objects are added
 lazily using [LinearMaps](https://github.com/JuliaLinearAlgebra/LinearMaps.jl).
 
+## Operator composition
+
 Effortlessly and efficiently composing operators is a powerful abstraction for
 integral equations, as it allows for the construction of complex systems from
-simple building blocks. To show this, let us show how one may construct the
+simple building blocks. To show this, let us show how to construct the
 Calderón projectors:
 
 ```math
@@ -148,14 +143,143 @@ As is well-known [nedelec2001acoustic; Theorem 3.1.3](@cite), the operators
 
 ```@example integral_operators
 using LinearMaps
+# create the block operator
 H = [-Dfmm Sfmm; -Nfmm Kfmm]
 C₊ = I / 2 + H
 C₋ = I / 2 - H
+# define two density functions on Γ
 u = map(q -> cos(q.coords[1] + q.coords[2]), Q)
 v = map(q-> q.coords[1], Q)
 x = [u; v]
+# compute the error in the projector identity
 e₊ = norm(C₊*(C₊*x) - C₊*x, Inf)
 e₋ = norm(C₋*(C₋*x) - C₋*x, Inf)
 println("projection error for C₊: $e₊")
 println("projection error for C₋: $e₋")
 ```
+
+We see that the error in the projector identity is small, as expected. Note that
+such compositions are not limited to the Calderón projectors, and can be used
+e.g. to construct the combined field integral equation (CFIE), or to compose a
+formulation with an operator preconditioner.
+
+## Custom kernels
+
+So far we have focused on problems for which Inti.jl provides predefined
+kernels, and used the high-level syntax of e.g. `single_double_layer` to
+construct the integral operators. We will now dig into the details of how to set
+up your own kernel function, and how to build an integral operator from it.
+
+!!! note "Integral operators coming from PDEs"
+    If your integral operator arises from a PDE, it is recommended to define a
+    new [`AbstractPDE`](@ref) type, and implement the required methods for
+    [`SingleLayerKernel`](@ref), [`DoubleLayerKernel`](@ref),
+    [`AdjointDoubleLayerKernel`](@ref), and [`HyperSingularKernel`](@ref). This
+    will enable the use of the high-level syntax for constructing boundary
+    integral operators, as well as the use of the compression and correction
+    methods specific to integral operators arising from PDEs.
+
+For the sake of simplicity, let us consider the following kernel representing
+the half-space Dirichlet Green function for Helmholtz's equation in 2D:
+
+```math
+    G_D(\boldsymbol{x}, \boldsymbol{y}) = \frac{i}{4} H^{(1)}_0(k |\boldsymbol{x} - \boldsymbol{y}|) - \frac{i}{4} H^{(1)}_0(k |\boldsymbol{x} - \boldsymbol{y}^*|),
+```
+
+where ``\boldsymbol{y}^* = (y_1, -y_2)``. We can define this kernel as a
+
+```@example integral_operators
+using SpecialFunctions # for hankelh1
+function helmholtz_kernel(target, source, k)
+    x, y  = Inti.coords(target), Inti.coords(source)
+    yc = SVector(y[1], -y[2])
+    d, dc  = norm(x-y), norm(x-yc)
+    # the singularity at x = y needs to be handled separately, so just put a zero
+    d == 0 ? zero(ComplexF64) : im / 4 * ( hankelh1(0, k * d) - hankelh1(0, k * dc))
+end
+```
+
+Let us now consider the integral operator ``S`` defined by:
+
+```math
+    S[\sigma](\boldsymbol{x}) = \int_{\Gamma} G_D(\boldsymbol{x}, \boldsymbol{y}) \sigma(\boldsymbol{y}) \mathrm{d} s_{\boldsymbol{y}}, \quad \boldsymbol{x} \in \Gamma.
+```
+
+We can represent `S` by an `IntegralOperator` type:
+
+```@example integral_operators
+k = 50π
+λ = 2π/k
+meshsize = λ / 10
+geo = Inti.parametric_curve(s -> SVector(cos(s), 2 + sin(s)), 0, 2π)
+Γ = Inti.Domain(geo)
+msh = Inti.meshgen(Γ; meshsize)
+Q = Inti.Quadrature(msh; qorder = 5)
+# create a local scope to capture `k`
+K = let k = k
+    (t,q) -> helmholtz_kernel(t,q,k)
+end
+Sop = Inti.IntegralOperator(K, Q, Q)
+```
+
+!!! note "Signature of custom kernels"
+    Kernel functions passed to `IntegralOperator` should always take two
+    arguments, `target` and `source`, which are both of
+    [`QuadratureNode`](@ref). This allows for extracting not only the
+    [`coords`](@ref) of the nodes, but also the [`normal`](@ref) vector if
+    needed (e.g. for double-layer or hypersingular kernels).
+
+The approximation of `Sop` now involves two steps:
+
+- build a dense operator `S₀` that efficiently computes the matrix-vector
+  product `Sop * x` for any vector `x`
+- correct for the inaccuracies of `S₀` due to singular/nearly-singular
+  interactions by adding to it a correction matrix `δS`
+
+For the first step, we will use a hierarchical matrix:
+
+```@example integral_operators
+using HMatrices
+S₀ = Inti.assemble_hmatrix(Sop; rtol = 1e-4)
+```
+
+The correction matrix `δS` will be constructed using [`adaptive_correction`](@ref):
+
+```@example integral_operators
+δS = Inti.adaptive_correction(Sop; tol = 1e-4, maxdist = 5*meshsize)
+```
+
+How exactly you add `S₀` and `δS` to get the final operator depends on the usage
+that you have in mind. For instance, you can use the `LinearMap` type to simply
+add them lazily:
+
+```@example integral_operators
+using LinearMaps
+S = LinearMap(S₀) + LinearMap(δS)
+```
+
+You can add `δS` to `S₀` to create a new object:
+
+```@example integral_operators
+S = S₀ + δS
+```
+
+or if performance/memory is a concern, you may want to directly add `δS` to `S₀` in-place:
+
+```@example integral_operators
+axpy!(1.0, δS, S₀)
+```
+
+All of these should give an identical matrix-vector product, but the later two
+allow e.g. for the use of direct solvers though an LU factorization.
+
+!!! warning "Limitations"
+    Integral operators defined from custom kernel functions do not support all
+    the features of the predefined ones. In particular, some singular
+    integration methods (e.g. the Density Interpolation Method) and acceleration
+    routines (e.g. Fast Multipole Method) used to correct for singular and
+    nearly singular integral operators, and to accelerate the matrix vector
+    products, are only available for specific kernels. Check the
+    [corrections](@ref "Correction methods") and [compression](@ref "Compression
+    methods") for more details concerning which methods are compatible with
+    custom kernels.

--- a/ext/IntiFMM2DExt.jl
+++ b/ext/IntiFMM2DExt.jl
@@ -8,7 +8,7 @@ function __init__()
     @info "Loading Inti.jl FMM2D extension"
 end
 
-function Inti._assemble_fmm2d(iop::Inti.IntegralOperator; atol = sqrt(eps()))
+function Inti._assemble_fmm2d(iop::Inti.IntegralOperator; rtol = sqrt(eps()))
     # unpack the necessary fields in the appropriate format
     m, n = size(iop)
     sources = Matrix{Float64}(undef, 2, n)
@@ -33,14 +33,14 @@ function Inti._assemble_fmm2d(iop::Inti.IntegralOperator; atol = sqrt(eps()))
             @. charges = -1 / (2 * π) * weights * x
             if same_surface
                 out =
-                    FMM2D.rfmm2d(; sources = sources, charges = charges, eps = atol, pg = 1)
+                    FMM2D.rfmm2d(; sources = sources, charges = charges, eps = rtol, pg = 1)
                 return copyto!(y, out.pot)
             else
                 out = FMM2D.rfmm2d(;
                     sources = sources,
                     charges = charges,
                     targets = targets,
-                    eps     = atol,
+                    eps     = rtol,
                     pgt     = 1,
                 )
                 return copyto!(y, out.pottarg)
@@ -66,7 +66,7 @@ function Inti._assemble_fmm2d(iop::Inti.IntegralOperator; atol = sqrt(eps()))
                     sources = sources,
                     dipstr  = dipstr,
                     dipvecs = dipvecs,
-                    eps     = atol,
+                    eps     = rtol,
                     pg      = 1,
                 )
                 return copyto!(y, out.pot)
@@ -76,7 +76,7 @@ function Inti._assemble_fmm2d(iop::Inti.IntegralOperator; atol = sqrt(eps()))
                     targets = targets,
                     dipstr  = dipstr,
                     dipvecs = dipvecs,
-                    eps     = atol,
+                    eps     = rtol,
                     pgt     = 1,
                 )
                 return copyto!(y, out.pottarg)
@@ -93,14 +93,14 @@ function Inti._assemble_fmm2d(iop::Inti.IntegralOperator; atol = sqrt(eps()))
             @. charges = -1 / (2 * π) * weights * x
             if same_surface
                 out =
-                    FMM2D.rfmm2d(; charges = charges, sources = sources, eps = atol, pg = 2)
+                    FMM2D.rfmm2d(; charges = charges, sources = sources, eps = rtol, pg = 2)
                 return copyto!(y, sum(xnormals .* out.grad; dims = 1) |> vec)
             else
                 out = FMM2D.rfmm2d(;
                     charges = charges,
                     sources = sources,
                     targets = targets,
-                    eps     = atol,
+                    eps     = rtol,
                     pgt     = 2,
                 )
                 return copyto!(y, sum(xnormals .* out.gradtarg; dims = 1) |> vec)
@@ -130,7 +130,7 @@ function Inti._assemble_fmm2d(iop::Inti.IntegralOperator; atol = sqrt(eps()))
                     dipvecs = dipvecs,
                     dipstr  = dipstrs,
                     sources = sources,
-                    eps     = atol,
+                    eps     = rtol,
                     pg      = 2,
                 )
                 return copyto!(y, sum(xnormals .* out.grad; dims = 1) |> vec)
@@ -140,7 +140,7 @@ function Inti._assemble_fmm2d(iop::Inti.IntegralOperator; atol = sqrt(eps()))
                     dipstr  = dipstrs,
                     sources = sources,
                     targets = targets,
-                    eps     = atol,
+                    eps     = rtol,
                     pgt     = 2,
                 )
                 return copyto!(y, sum(xnormals .* out.gradtarg; dims = 1) |> vec)
@@ -158,7 +158,7 @@ function Inti._assemble_fmm2d(iop::Inti.IntegralOperator; atol = sqrt(eps()))
                     zk      = zk,
                     sources = sources,
                     charges = charges,
-                    eps     = atol,
+                    eps     = rtol,
                     pg      = 1,
                 )
                 return copyto!(y, out.pot)
@@ -168,7 +168,7 @@ function Inti._assemble_fmm2d(iop::Inti.IntegralOperator; atol = sqrt(eps()))
                     sources = sources,
                     charges = charges,
                     targets = targets,
-                    eps     = atol,
+                    eps     = rtol,
                     pgt     = 1,
                 )
                 return copyto!(y, out.pottarg)
@@ -196,7 +196,7 @@ function Inti._assemble_fmm2d(iop::Inti.IntegralOperator; atol = sqrt(eps()))
                     sources = sources,
                     dipstr  = dipstrs,
                     dipvecs = dipvecs,
-                    eps     = atol,
+                    eps     = rtol,
                     pg      = 1,
                 )
                 return copyto!(y, out.pot)
@@ -207,7 +207,7 @@ function Inti._assemble_fmm2d(iop::Inti.IntegralOperator; atol = sqrt(eps()))
                     targets = targets,
                     dipstr  = dipstrs,
                     dipvecs = dipvecs,
-                    eps     = atol,
+                    eps     = rtol,
                     pgt     = 1,
                 )
                 return copyto!(y, out.pottarg)
@@ -228,7 +228,7 @@ function Inti._assemble_fmm2d(iop::Inti.IntegralOperator; atol = sqrt(eps()))
                     zk      = zk,
                     charges = charges,
                     sources = sources,
-                    eps     = atol,
+                    eps     = rtol,
                     pg      = 2,
                 )
                 return copyto!(y, sum(xnormals .* out.grad; dims = 1) |> vec)
@@ -238,7 +238,7 @@ function Inti._assemble_fmm2d(iop::Inti.IntegralOperator; atol = sqrt(eps()))
                     charges = charges,
                     sources = sources,
                     targets = targets,
-                    eps     = atol,
+                    eps     = rtol,
                     pgt     = 2,
                 )
                 return copyto!(y, sum(xnormals .* out.gradtarg; dims = 1) |> vec)
@@ -270,7 +270,7 @@ function Inti._assemble_fmm2d(iop::Inti.IntegralOperator; atol = sqrt(eps()))
                     dipvecs = dipvecs,
                     dipstr  = dipstrs,
                     sources = sources,
-                    eps     = atol,
+                    eps     = rtol,
                     pg      = 2,
                 )
                 return copyto!(y, sum(xnormals .* out.grad; dims = 1) |> vec)
@@ -281,7 +281,7 @@ function Inti._assemble_fmm2d(iop::Inti.IntegralOperator; atol = sqrt(eps()))
                     dipstr  = dipstrs,
                     sources = sources,
                     targets = targets,
-                    eps     = atol,
+                    eps     = rtol,
                     pgt     = 2,
                 )
                 return copyto!(y, sum(xnormals .* out.gradtarg; dims = 1) |> vec)

--- a/ext/IntiFMM3DExt.jl
+++ b/ext/IntiFMM3DExt.jl
@@ -8,7 +8,7 @@ function __init__()
     @info "Loading Inti.jl FMM3D extension"
 end
 
-function Inti._assemble_fmm3d(iop::Inti.IntegralOperator; atol = sqrt(eps()))
+function Inti._assemble_fmm3d(iop::Inti.IntegralOperator; rtol = sqrt(eps()))
     # unpack the necessary fields in the appropriate format
     m, n = size(iop)
     targets = Matrix{Float64}(undef, 3, m)
@@ -27,7 +27,7 @@ function Inti._assemble_fmm3d(iop::Inti.IntegralOperator; atol = sqrt(eps()))
         return LinearMaps.LinearMap{Float64}(m, n) do y, x
             # multiply by weights and constant
             @. charges = 1 / (4 * π) * weights * x
-            out = FMM3D.lfmm3d(atol, sources; charges, targets, pgt = 1)
+            out = FMM3D.lfmm3d(rtol, sources; charges, targets, pgt = 1)
             return copyto!(y, out.pottarg)
         end
     elseif K isa Inti.DoubleLayerKernel{Float64,<:Inti.Laplace{3}}
@@ -41,7 +41,7 @@ function Inti._assemble_fmm3d(iop::Inti.IntegralOperator; atol = sqrt(eps()))
             for j in 1:n
                 dipvecs[:, j] = 1 / (4 * π) * view(normals, :, j) * x[j] * weights[j]
             end
-            out = FMM3D.lfmm3d(atol, sources; dipvecs, targets, pgt = 1)
+            out = FMM3D.lfmm3d(rtol, sources; dipvecs, targets, pgt = 1)
             return copyto!(y, out.pottarg)
         end
     elseif K isa Inti.AdjointDoubleLayerKernel{Float64,<:Inti.Laplace{3}}
@@ -53,7 +53,7 @@ function Inti._assemble_fmm3d(iop::Inti.IntegralOperator; atol = sqrt(eps()))
         return LinearMaps.LinearMap{Float64}(m, n) do y, x
             # multiply by weights and constant
             @. charges = 1 / (4 * π) * weights * x
-            out = FMM3D.lfmm3d(atol, sources; charges, targets, pgt = 2)
+            out = FMM3D.lfmm3d(rtol, sources; charges, targets, pgt = 2)
             return copyto!(y, sum(xnormals .* out.gradtarg; dims = 1) |> vec)
         end
     elseif K isa Inti.HyperSingularKernel{Float64,<:Inti.Laplace{3}}
@@ -71,7 +71,7 @@ function Inti._assemble_fmm3d(iop::Inti.IntegralOperator; atol = sqrt(eps()))
             for j in 1:n
                 dipvecs[:, j] = 1 / (4 * π) * view(ynormals, :, j) * x[j] * weights[j]
             end
-            out = FMM3D.lfmm3d(atol, sources; dipvecs, targets, pgt = 2)
+            out = FMM3D.lfmm3d(rtol, sources; dipvecs, targets, pgt = 2)
             return copyto!(y, sum(xnormals .* out.gradtarg; dims = 1) |> vec)
         end
         # Helmholtz
@@ -81,7 +81,7 @@ function Inti._assemble_fmm3d(iop::Inti.IntegralOperator; atol = sqrt(eps()))
         return LinearMaps.LinearMap{ComplexF64}(m, n) do y, x
             # multiply by weights and constant
             @. charges = 1 / (4 * π) * weights * x
-            out = FMM3D.hfmm3d(atol, zk, sources; charges, targets, pgt = 1)
+            out = FMM3D.hfmm3d(rtol, zk, sources; charges, targets, pgt = 1)
             return copyto!(y, out.pottarg)
         end
     elseif K isa Inti.DoubleLayerKernel{ComplexF64,<:Inti.Helmholtz{3}}
@@ -96,7 +96,7 @@ function Inti._assemble_fmm3d(iop::Inti.IntegralOperator; atol = sqrt(eps()))
             for j in 1:n
                 dipvecs[:, j] = 1 / (4 * π) * view(normals, :, j) * x[j] * weights[j]
             end
-            out = FMM3D.hfmm3d(atol, zk, sources; dipvecs, targets, pgt = 1)
+            out = FMM3D.hfmm3d(rtol, zk, sources; dipvecs, targets, pgt = 1)
             return copyto!(y, out.pottarg)
         end
     elseif K isa Inti.AdjointDoubleLayerKernel{ComplexF64,<:Inti.Helmholtz{3}}
@@ -109,7 +109,7 @@ function Inti._assemble_fmm3d(iop::Inti.IntegralOperator; atol = sqrt(eps()))
         return LinearMaps.LinearMap{ComplexF64}(m, n) do y, x
             # multiply by weights and constant
             @. charges = 1 / (4 * π) * weights * x
-            out = FMM3D.hfmm3d(atol, zk, sources; charges, targets, pgt = 2)
+            out = FMM3D.hfmm3d(rtol, zk, sources; charges, targets, pgt = 2)
             return copyto!(y, sum(xnormals .* out.gradtarg; dims = 1) |> vec)
         end
     elseif K isa Inti.HyperSingularKernel{ComplexF64,<:Inti.Helmholtz{3}}
@@ -128,7 +128,7 @@ function Inti._assemble_fmm3d(iop::Inti.IntegralOperator; atol = sqrt(eps()))
             for j in 1:n
                 dipvecs[:, j] = 1 / (4 * π) * view(ynormals, :, j) * x[j] * weights[j]
             end
-            out = FMM3D.hfmm3d(atol, zk, sources; dipvecs, targets, pgt = 2)
+            out = FMM3D.hfmm3d(rtol, zk, sources; dipvecs, targets, pgt = 2)
             return copyto!(y, sum(xnormals .* out.gradtarg; dims = 1) |> vec)
         end
     else

--- a/src/api.jl
+++ b/src/api.jl
@@ -72,14 +72,14 @@ function single_double_layer(;
     Dop         = IntegralOperator(dG, target, source)
     # handle compression
     if compression.method == :hmatrix
-        Smat = assemble_hmatrix(Sop; atol = compression.tol)
-        Dmat = assemble_hmatrix(Dop; atol = compression.tol)
+        Smat = assemble_hmatrix(Sop; rtol = compression.tol)
+        Dmat = assemble_hmatrix(Dop; rtol = compression.tol)
     elseif compression.method == :none
         Smat = assemble_matrix(Sop)
         Dmat = assemble_matrix(Dop)
     elseif compression.method == :fmm
-        Smat = assemble_fmm(Sop; atol = compression.tol)::LinearMap
-        Dmat = assemble_fmm(Dop; atol = compression.tol)::LinearMap
+        Smat = assemble_fmm(Sop; rtol = compression.tol)::LinearMap
+        Dmat = assemble_fmm(Dop; rtol = compression.tol)::LinearMap
     else
         error("Unknown compression method. Available options: $COMPRESSION_METHODS")
     end
@@ -107,14 +107,14 @@ function single_double_layer(;
             Dop_dim = IntegralOperator(dG, target[glob_near_trgs], source)
             # compress 'em
             if compression.method == :hmatrix
-                Sop_dim_mat = assemble_hmatrix(Sop_dim; atol = compression.tol)
-                Dop_dim_mat = assemble_hmatrix(Dop_dim; atol = compression.tol)
+                Sop_dim_mat = assemble_hmatrix(Sop_dim; rtol = compression.tol)
+                Dop_dim_mat = assemble_hmatrix(Dop_dim; rtol = compression.tol)
             elseif compression.method == :none
                 Sop_dim_mat = assemble_matrix(Sop_dim)
                 Dop_dim_mat = assemble_matrix(Dop_dim)
             elseif compression.method == :fmm
-                Sop_dim_mat = assemble_fmm(Sop_dim; atol = compression.tol)::LinearMap
-                Dop_dim_mat = assemble_fmm(Dop_dim; atol = compression.tol)::LinearMap
+                Sop_dim_mat = assemble_fmm(Sop_dim; rtol = compression.tol)::LinearMap
+                Dop_dim_mat = assemble_fmm(Dop_dim; rtol = compression.tol)::LinearMap
             else
                 error("Unknown compression method. Available options: $COMPRESSION_METHODS")
             end
@@ -234,9 +234,9 @@ function volume_potential(; pde, target, source::Quadrature, compression, correc
     if compression.method == :none
         Vmat = assemble_matrix(V)
     elseif compression.method == :hmatrix
-        Vmat = assemble_hmatrix(V; atol = compression.tol)
+        Vmat = assemble_hmatrix(V; rtol = compression.tol)
     elseif compression.method == :fmm
-        Vmat = assemble_fmm(V; atol = compression.tol)
+        Vmat = assemble_fmm(V; rtol = compression.tol)
     else
         error("Unknown compression method. Available options: $COMPRESSION_METHODS")
     end

--- a/src/nystrom.jl
+++ b/src/nystrom.jl
@@ -137,8 +137,9 @@ end
 Assemble an H-matrix representation of the discretized integral operator `iop`
 using the `HMatrices.jl` library.
 
-See the [`HMatrices.assemble_hmatrix`](@extref) function from `HMatrices.jl` for
-more details on the keyword arguments.
+See the documentation of
+[`HMatrices`](https://github.com/IntegralEquations/HMatrices.jl) for more
+details on usage and other keyword arguments.
 """
 function assemble_hmatrix(args...; kwargs...)
     return error("Inti.assemble_hmatrix not found. Did you forget to import HMatrices?")

--- a/src/nystrom.jl
+++ b/src/nystrom.jl
@@ -137,8 +137,8 @@ end
 Assemble an H-matrix representation of the discretized integral operator `iop`
 using the `HMatrices.jl` library.
 
-See the `assemble_hmatrix` function from `HMatrices.jl` for more details on the
-keyword arguments.
+See the [`HMatrices.assemble_hmatrix`](@extref) function from `HMatrices.jl` for
+more details on the keyword arguments.
 """
 function assemble_hmatrix(args...; kwargs...)
     return error("Inti.assemble_hmatrix not found. Did you forget to import HMatrices?")

--- a/src/reference_integration.jl
+++ b/src/reference_integration.jl
@@ -187,9 +187,9 @@ A tensor-product of one-dimension quadrature rules. Integrates over `[0,1]^N`.
 
 # Examples
 ```julia
-qx = Fejer(10)
-qy = TrapezoidalOpen(15)
-q  = TensorProductQuadrature(qx,qy)
+qx = Inti.Fejer(10)
+qy = Inti.Fejer(15)
+q  = Inti.TensorProductQuadrature(qx,qy)
 ```
 """
 struct TensorProductQuadrature{N,Q} <: ReferenceQuadrature{ReferenceHyperCube{N}}
@@ -208,8 +208,8 @@ function (q::TensorProductQuadrature{N})() where {N}
         return map(x -> x[1], x1d) # convert the `SVector{1,T}` to just `T`
     end
     weights1d = map(q -> q()[2], q.quads1d)
-    nodes_iter = (SVector(x) for x in Iterators.product(nodes1d...))
-    weights_iter = (prod(w) for w in Iterators.product(weights1d...))
+    nodes_iter = [SVector(x) for x in Iterators.product(nodes1d...)]
+    weights_iter = [prod(w) for w in Iterators.product(weights1d...)]
     return nodes_iter, weights_iter
 end
 

--- a/test/fmm2d_test.jl
+++ b/test/fmm2d_test.jl
@@ -27,7 +27,7 @@ for pde in (Inti.Laplace(; dim = 2), Inti.Helmholtz(; dim = 2, k = 1.2))
         )
             for Γ_quad in (Γ₁_quad, Γ₂_quad)
                 iop = Inti.IntegralOperator(K, Γ₁_quad, Γ_quad)
-                iop_fmm = Inti.assemble_fmm(iop; atol = 1e-8)
+                iop_fmm = Inti.assemble_fmm(iop; rtol = 1e-8)
                 x = rand(eltype(iop), size(iop, 2))
                 yapprox = iop_fmm * x
                 # test on a given index set
@@ -35,7 +35,7 @@ for pde in (Inti.Laplace(; dim = 2), Inti.Helmholtz(; dim = 2, k = 1.2))
                 exact = iop[idx_test, :] * x
                 # The discrepancy in tolerance for assemble_fmm and the test is because
                 # the library is tuned for error in potential but not in gradient
-                @test yapprox[idx_test] ≈ exact atol = 5e-6
+                @test yapprox[idx_test] ≈ exact rtol = 5e-6
             end
         end
     end

--- a/test/fmm3d_test.jl
+++ b/test/fmm3d_test.jl
@@ -26,13 +26,13 @@ for pde in (Inti.Laplace(; dim = 3), Inti.Helmholtz(; dim = 3, k = 1.2))
         )
             for Γ_quad in (Γ₁_quad, Γ₂_quad)
                 iop = Inti.IntegralOperator(K, Γ₁_quad, Γ_quad)
-                iop_fmm = Inti.assemble_fmm(iop; atol = 1e-8)
+                iop_fmm = Inti.assemble_fmm(iop; rtol = 1e-8)
                 x = rand(eltype(iop), size(iop, 2))
                 yapprox = iop_fmm * x
                 # test on a given index set
                 idx_test = rand(1:size(iop, 1), 10)
                 exact = iop[idx_test, :] * x
-                @test yapprox[idx_test] ≈ exact atol = 1e-7
+                @test yapprox[idx_test] ≈ exact rtol = 1e-7
             end
         end
     end

--- a/test/quadrature_test.jl
+++ b/test/quadrature_test.jl
@@ -54,7 +54,7 @@ using Inti
             Γ = Inti.external_boundary(Ω)
             quad = Inti.Quadrature(M[Γ]; qorder = 4) # NystromMesh of surface Γ
             area = Inti.integrate(x -> 1, quad)
-            @test isapprox(area, 4 * π * r^2, atol = 5e-2)
+            @test isapprox(area, 4 * π * r^2, rtol = 5e-2)
             exact = map(f, M[Γ].nodes)
             approx = Inti.quadrature_to_node_vals(quad, map(q -> f(q.coords), quad))
             @test exact ≈ approx


### PR DESCRIPTION
A few other minor changes besides the writing of two new doc pages:

- use `DocumenterInterLinks` to cite weak dependencies
- add citations concerning compression methods to `.bib`
- change `atol` to `rtol` as a keyword for fmm-based compression methods. As per the [FMM3D documentation](https://fmm3d.readthedocs.io/en/latest/), their epsilon parameter is a "requested relative precision"
