### PR TITLE
Add support for linear (static) elasticity

### DIFF
--- a/src/kernels.jl
+++ b/src/kernels.jl
@@ -356,3 +356,151 @@ function (ADL::AdjointDoubleLayerKernel{T,<:Stokes{N}})(target, source)::T where
 end
 
 # TODO: Stokes hypersingular kernel
+
+################################################################################
+################################# Elastostatic #################################
+################################################################################
+
+"""
+    struct Elastostatic{N,T} <: AbstractPDE{N}
+
+Elastostatic equation in `N` dimensions: μΔu + (μ+λ)∇(∇⋅u) = 0. Note that the
+displacement u is a vector of length `N` since this is a vectorial problem.
+"""
+struct Elastostatic{N,T} <: AbstractPDE{N}
+    μ::T
+    λ::T
+end
+Elastostatic(; μ, λ, dim) = Elastostatic{dim}(promote(μ, λ)...)
+Elastostatic{N}(μ::T, λ::T) where {N,T} = Elastostatic{N,T}(μ, λ)
+
+function Base.show(io::IO, pde::Elastostatic)
+    return print(io, "μΔu + (μ+λ)∇(∇⋅u) = 0")
+end
+
+parameters(pde::Elastostatic) = pde.μ, pde.λ
+
+default_kernel_eltype(::Elastostatic{N}) where {N} = SMatrix{N,N,Float64,N * N}
+default_density_eltype(::Elastostatic{N}) where {N} = SVector{N,Float64}
+
+function (SL::SingleLayerKernel{T,<:Elastostatic{N}})(target, source)::T where {N,T}
+    μ, λ = parameters(pde(SL))
+    ν = λ / (2 * (μ + λ))
+    x = coords(target)
+    y = coords(source)
+    r = x .- y
+    d = norm(r)
+    d == 0 && return zero(T)
+    RRT = r * transpose(r) # r ⊗ rᵗ
+    if N == 2
+        ID = SMatrix{2,2,Float64,4}(1, 0, 0, 1)
+        return 1 / (8π * μ * (1 - ν)) * (-(3 - 4 * ν) * log(d) * ID + RRT / d^2)
+        # return (λ + 3μ)/(4*π*(N-1)*μ*(λ+2μ))* (-log(d)*ID + (λ+μ)/(λ+3μ)*RRT/d^2)
+    elseif N == 3
+        ID = SMatrix{3,3,Float64,9}(1, 0, 0, 0, 1, 0, 0, 0, 1)
+        return 1 / (16π * μ * (1 - ν) * d) * ((3 - 4 * ν) * ID + RRT / d^2)
+    end
+end
+
+function (DL::DoubleLayerKernel{T,<:Elastostatic{N}})(target, source)::T where {N,T}
+    μ, λ = parameters(pde(DL))
+    ν = λ / (2 * (μ + λ))
+    x = coords(target)
+    y = coords(source)
+    ny = normal(source)
+    ν = λ / (2 * (μ + λ))
+    r = x .- y
+    d = norm(r)
+    d == 0 && return zero(T)
+    RRT = r * transpose(r) # r ⊗ rᵗ
+    drdn = -dot(r, ny) / d
+    if N == 2
+        ID = SMatrix{2,2,Float64,4}(1, 0, 0, 1)
+        return -1 / (4π * (1 - ν) * d) * (
+            drdn * ((1 - 2ν) * ID + 2 * RRT / d^2) +
+            (1 - 2ν) / d * (r * transpose(ny) - ny * transpose(r))
+        )
+    elseif N == 3
+        ID = SMatrix{3,3,Float64,9}(1, 0, 0, 0, 1, 0, 0, 0, 1)
+        return -1 / (8π * (1 - ν) * d^2) * (
+            drdn * ((1 - 2 * ν) * ID + 3 * RRT / d^2) +
+            (1 - 2 * ν) / d * (r * transpose(ny) - ny * transpose(r))
+        )
+    end
+end
+
+function (ADL::AdjointDoubleLayerKernel{T,<:Elastostatic{N}})(target, source)::T where {N,T}
+    # DL = DoubleLayerKernel{T}(pde(ADL))
+    # return -DL(x,y,nx) |> transpose
+    μ, λ = parameters(pde(ADL))
+    ν = λ / (2 * (μ + λ))
+    x = coords(target)
+    nx = normal(target)
+    y = coords(source)
+    ν = λ / (2 * (μ + λ))
+    r = x .- y
+    d = norm(r)
+    d == 0 && return zero(T)
+    RRT = r * transpose(r) # r ⊗ rᵗ
+    drdn = -dot(r, nx) / d
+    if N == 2
+        ID = SMatrix{2,2,Float64,4}(1, 0, 0, 1)
+        out =
+            -1 / (4π * (1 - ν) * d) * (
+                drdn * ((1 - 2ν) * ID + 2 * RRT / d^2) +
+                (1 - 2ν) / d * (r * transpose(nx) - nx * transpose(r))
+            )
+        return -transpose(out)
+    elseif N == 3
+        ID = SMatrix{3,3,Float64,9}(1, 0, 0, 0, 1, 0, 0, 0, 1)
+        out =
+            -1 / (8π * (1 - ν) * d^2) * (
+                drdn * ((1 - 2 * ν) * ID + 3 * RRT / d^2) +
+                (1 - 2 * ν) / d * (r * transpose(nx) - nx * transpose(r))
+            )
+        return -transpose(out)
+    end
+end
+
+function (HS::HyperSingularKernel{T,<:Elastostatic{N}})(target, source)::T where {N,T}
+    μ, λ = parameters(pde(HS))
+    ν = λ / (2 * (μ + λ))
+    x = coords(target)
+    nx = normal(target)
+    y = coords(source)
+    ny = normal(source)
+    r = x .- y
+    d = norm(r)
+    d == 0 && return zero(T)
+    RRT = r * transpose(r) # r ⊗ rᵗ
+    drdn = dot(r, ny) / d
+    if N == 2
+        ID = SMatrix{2,2,Float64,4}(1, 0, 0, 1)
+        return μ / (2π * (1 - ν) * d^2) * (
+            2 * drdn / d * (
+                (1 - 2ν) * nx * transpose(r) + ν * (dot(r, nx) * ID + r * transpose(nx)) -
+                4 * dot(r, nx) * RRT / d^2
+            ) +
+            2 * ν / d^2 * (dot(r, nx) * ny * transpose(r) + dot(nx, ny) * RRT) +
+            (1 - 2 * ν) * (
+                2 / d^2 * dot(r, nx) * r * transpose(ny) +
+                dot(nx, ny) * ID +
+                ny * transpose(nx)
+            ) - (1 - 4ν) * nx * transpose(ny)
+        )
+    elseif N == 3
+        ID = SMatrix{3,3,Float64,9}(1, 0, 0, 0, 1, 0, 0, 0, 1)
+        return μ / (4π * (1 - ν) * d^3) * (
+            3 * drdn / d * (
+                (1 - 2ν) * nx * transpose(r) + ν * (dot(r, nx) * ID + r * transpose(nx)) -
+                5 * dot(r, nx) * RRT / d^2
+            ) +
+            3 * ν / d^2 * (dot(r, nx) * ny * transpose(r) + dot(nx, ny) * RRT) +
+            (1 - 2 * ν) * (
+                3 / d^2 * dot(r, nx) * r * transpose(ny) +
+                dot(nx, ny) * ID +
+                ny * transpose(nx)
+            ) - (1 - 4ν) * nx * transpose(ny)
+        )
+    end
+end

--- a/src/kernels.jl
+++ b/src/kernels.jl
@@ -393,12 +393,9 @@ function (SL::SingleLayerKernel{T,<:Elastostatic{N}})(target, source)::T where {
     d == 0 && return zero(T)
     RRT = r * transpose(r) # r ⊗ rᵗ
     if N == 2
-        ID = SMatrix{2,2,Float64,4}(1, 0, 0, 1)
-        return 1 / (8π * μ * (1 - ν)) * (-(3 - 4 * ν) * log(d) * ID + RRT / d^2)
-        # return (λ + 3μ)/(4*π*(N-1)*μ*(λ+2μ))* (-log(d)*ID + (λ+μ)/(λ+3μ)*RRT/d^2)
+        return 1 / (8π * μ * (1 - ν)) * (-(3 - 4 * ν) * log(d) * I + RRT / d^2)
     elseif N == 3
-        ID = SMatrix{3,3,Float64,9}(1, 0, 0, 0, 1, 0, 0, 0, 1)
-        return 1 / (16π * μ * (1 - ν) * d) * ((3 - 4 * ν) * ID + RRT / d^2)
+        return 1 / (16π * μ * (1 - ν) * d) * ((3 - 4 * ν) * I + RRT / d^2)
     end
 end
 
@@ -415,23 +412,19 @@ function (DL::DoubleLayerKernel{T,<:Elastostatic{N}})(target, source)::T where {
     RRT = r * transpose(r) # r ⊗ rᵗ
     drdn = -dot(r, ny) / d
     if N == 2
-        ID = SMatrix{2,2,Float64,4}(1, 0, 0, 1)
         return -1 / (4π * (1 - ν) * d) * (
-            drdn * ((1 - 2ν) * ID + 2 * RRT / d^2) +
+            drdn * ((1 - 2ν) * I + 2 * RRT / d^2) +
             (1 - 2ν) / d * (r * transpose(ny) - ny * transpose(r))
         )
     elseif N == 3
-        ID = SMatrix{3,3,Float64,9}(1, 0, 0, 0, 1, 0, 0, 0, 1)
         return -1 / (8π * (1 - ν) * d^2) * (
-            drdn * ((1 - 2 * ν) * ID + 3 * RRT / d^2) +
+            drdn * ((1 - 2 * ν) * I + 3 * RRT / d^2) +
             (1 - 2 * ν) / d * (r * transpose(ny) - ny * transpose(r))
         )
     end
 end
 
 function (ADL::AdjointDoubleLayerKernel{T,<:Elastostatic{N}})(target, source)::T where {N,T}
-    # DL = DoubleLayerKernel{T}(pde(ADL))
-    # return -DL(x,y,nx) |> transpose
     μ, λ = parameters(pde(ADL))
     ν = λ / (2 * (μ + λ))
     x = coords(target)
@@ -444,18 +437,16 @@ function (ADL::AdjointDoubleLayerKernel{T,<:Elastostatic{N}})(target, source)::T
     RRT = r * transpose(r) # r ⊗ rᵗ
     drdn = -dot(r, nx) / d
     if N == 2
-        ID = SMatrix{2,2,Float64,4}(1, 0, 0, 1)
         out =
             -1 / (4π * (1 - ν) * d) * (
-                drdn * ((1 - 2ν) * ID + 2 * RRT / d^2) +
+                drdn * ((1 - 2ν) * I + 2 * RRT / d^2) +
                 (1 - 2ν) / d * (r * transpose(nx) - nx * transpose(r))
             )
         return -transpose(out)
     elseif N == 3
-        ID = SMatrix{3,3,Float64,9}(1, 0, 0, 0, 1, 0, 0, 0, 1)
         out =
             -1 / (8π * (1 - ν) * d^2) * (
-                drdn * ((1 - 2 * ν) * ID + 3 * RRT / d^2) +
+                drdn * ((1 - 2 * ν) * I + 3 * RRT / d^2) +
                 (1 - 2 * ν) / d * (r * transpose(nx) - nx * transpose(r))
             )
         return -transpose(out)
@@ -475,30 +466,28 @@ function (HS::HyperSingularKernel{T,<:Elastostatic{N}})(target, source)::T where
     RRT = r * transpose(r) # r ⊗ rᵗ
     drdn = dot(r, ny) / d
     if N == 2
-        ID = SMatrix{2,2,Float64,4}(1, 0, 0, 1)
         return μ / (2π * (1 - ν) * d^2) * (
             2 * drdn / d * (
-                (1 - 2ν) * nx * transpose(r) + ν * (dot(r, nx) * ID + r * transpose(nx)) -
+                (1 - 2ν) * nx * transpose(r) + ν * (dot(r, nx) * I + r * transpose(nx)) -
                 4 * dot(r, nx) * RRT / d^2
             ) +
             2 * ν / d^2 * (dot(r, nx) * ny * transpose(r) + dot(nx, ny) * RRT) +
             (1 - 2 * ν) * (
                 2 / d^2 * dot(r, nx) * r * transpose(ny) +
-                dot(nx, ny) * ID +
+                dot(nx, ny) * I +
                 ny * transpose(nx)
             ) - (1 - 4ν) * nx * transpose(ny)
         )
     elseif N == 3
-        ID = SMatrix{3,3,Float64,9}(1, 0, 0, 0, 1, 0, 0, 0, 1)
         return μ / (4π * (1 - ν) * d^3) * (
             3 * drdn / d * (
-                (1 - 2ν) * nx * transpose(r) + ν * (dot(r, nx) * ID + r * transpose(nx)) -
+                (1 - 2ν) * nx * transpose(r) + ν * (dot(r, nx) * I + r * transpose(nx)) -
                 5 * dot(r, nx) * RRT / d^2
             ) +
             3 * ν / d^2 * (dot(r, nx) * ny * transpose(r) + dot(nx, ny) * RRT) +
             (1 - 2 * ν) * (
                 3 / d^2 * dot(r, nx) * r * transpose(ny) +
-                dot(nx, ny) * ID +
+                dot(nx, ny) * I +
                 ny * transpose(nx)
             ) - (1 - 4ν) * nx * transpose(ny)
         )


### PR DESCRIPTION
- Add `Elastostatic`, a new `AbstractPDE`
- Use the native geometry in the `dim_test.jl`
- Fix a bug on `assemble_bdim` related to transposing the computed weights (only relevant to kernels such as elastostatic's double-layer, which are vector-valued and not symmetric)