### PR TITLE
Stokes FMM3D support

### DIFF
--- a/test/fmm3d_test.jl
+++ b/test/fmm3d_test.jl
@@ -16,7 +16,11 @@ include("test_utils.jl")
 Γ₂ = Inti.external_boundary(Ω₂)
 Γ₂_quad = Inti.Quadrature(view(msh₂, Γ₂); qorder = 3)
 
-for pde in (Inti.Laplace(; dim = 3), Inti.Helmholtz(; dim = 3, k = 1.2))
+for pde in (
+    Inti.Laplace(; dim = 3),
+    Inti.Helmholtz(; dim = 3, k = 1.2),
+    Inti.Stokes(; dim = 3, μ = 0.5),
+)
     @testset "PDE: $pde" begin
         for K in (
             Inti.DoubleLayerKernel(pde),
@@ -24,10 +28,13 @@ for pde in (Inti.Laplace(; dim = 3), Inti.Helmholtz(; dim = 3, k = 1.2))
             Inti.AdjointDoubleLayerKernel(pde),
             Inti.HyperSingularKernel(pde),
         )
+            # TODO Stokes has only single and double layer implemented for now
+            (K isa Inti.AdjointDoubleLayerKernel && pde isa Inti.Stokes) && continue
+            (K isa Inti.HyperSingularKernel && pde isa Inti.Stokes) && continue
             for Γ_quad in (Γ₁_quad, Γ₂_quad)
                 iop = Inti.IntegralOperator(K, Γ₁_quad, Γ_quad)
                 iop_fmm = Inti.assemble_fmm(iop; rtol = 1e-8)
-                x = rand(eltype(iop), size(iop, 2))
+                x = rand(Inti.default_density_eltype(pde), size(iop, 2))
                 yapprox = iop_fmm * x
                 # test on a given index set
                 idx_test = rand(1:size(iop, 1), 10)


### PR DESCRIPTION
This PR adds acceleration support for `SingleLayerKernel` and `DoubleLayerKernel` Stokes support in 3D via FMM3D.

The `AdjointDoubleLayerKernel` and `HyperSingularKernel` (not even implemented in `kernels.jl`) are not yet implemented; it is not clear if it is possible to use FMM3D for such purposes.