### PR TITLE
Update Poisson example

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -39,13 +39,7 @@ end
 # Generate examples using Literate
 const examples_dir = joinpath(Inti.PROJECT_ROOT, "docs", "src", "examples")
 const generated_dir = joinpath(Inti.PROJECT_ROOT, "docs", "src", "examples", "generated")
-const examples = [
-    "toy_example.jl",
-    "helmholtz_scattering.jl",
-    "lippmann_schwinger.jl",
-    "poisson.jl",
-    "stokes_drag.jl",
-]
+const examples = ["toy_example.jl", "helmholtz_scattering.jl"]
 for t in examples
     println("\n*** Generating $t example")
     @time begin
@@ -100,6 +94,7 @@ makedocs(;
         "Examples" => [
             "examples/generated/toy_example.md",
             "examples/generated/helmholtz_scattering.md",
+            "examples/poisson.md",
             # "examples/generated/lippmann_schwinger.md",
             # "examples/generated/poisson.md",
             # "examples/generated/stokes_drag.md",

--- a/docs/src/examples/poisson.md
+++ b/docs/src/examples/poisson.md
@@ -28,7 +28,7 @@ To solve this problem using integral equations, we split the solution ``u`` into
 a particular solution ``u_p`` and a homogeneous solution ``u_h``:
 
 ```math
-  u = u_p + u_h
+  u = u_p + u_h.
 ```
 
 The function ``u_p`` is given by
@@ -43,8 +43,8 @@ The function ``u_h`` satisfies the homogeneous problem
 
 ```math
   \begin{align*}
-      \Delta u_h &= 0  \quad &&\text{in } \quad \Omega \\
-      u_h &= g - u_p  \quad &&\text{on }  \quad \Gamma
+      \Delta u_h &= 0,  \quad &&\text{in } \quad \Omega, \\
+      u_h &= g - u_p,  \quad &&\text{on }  \quad \Gamma,
   \end{align*}
 ```
 
@@ -52,21 +52,20 @@ which can be solved using the integral equation method. In particular, for this
 example, we employ a double-layer formulation:
 
 ```math
-u_h(\boldsymbol{r}) = \int_{\Gamma} G(\boldsymbol{r}, \boldsymbol{r'}) \sigma(\boldsymbol{r}') d\boldsymbol{r'}.
+u_h(\boldsymbol{r}) = \int_{\Gamma} G(\boldsymbol{r}, \boldsymbol{r'}) \sigma(\boldsymbol{r}') d\boldsymbol{r'},
 ```
 
-where the density function ``\sigma`` solves the following integral equation:
+where the density function ``\sigma`` solves the integral equation
 
 ```math
   -\frac{\sigma(\boldsymbol{x})}{2} + \int_{\Gamma} \partial_{\nu_{\boldsymbol{y}}}G(\boldsymbol{x}, \boldsymbol{y}) \sigma(\boldsymbol{y}) \ \mathrm{d} s_{\boldsymbol{y}} = g(\boldsymbol{x}) - u_p(\boldsymbol{x}).
 ```
 
-In what follows we will illustrate how to solve the problem above using integral
-equations.
+In what follows we illustrate how to solve the problem in this manner.
 
 ## Geometry and mesh
 
-We use the *Gmsh API* to create a jellyfish shaped domain and to generate a
+We use the *Gmsh API* to create a jellyfish-shaped domain and to generate a
 second order mesh of its interior and boundary:
 
 ```@example poisson
@@ -87,7 +86,8 @@ msh = Inti.import_mesh(; dim = 2)
 gmsh.finalize()
 ```
 
-We can now extract ``\Omega`` and ``\Gamma`` from the mesh:
+We can now extract components of the mesh corresponding to the ``\Omega`` and
+``\Gamma`` domains:
 
 ```@example poisson
 Ω = Inti.Domain(e -> Inti.geometric_dimension(e) == 2, msh)
@@ -117,7 +117,9 @@ nothing # hide
 
 ## Integral operators
 
-We can now assemble the required volume potential:
+We can now assemble the required volume potential. To obtain the value of the particular solution
+``u_p`` on the boundary for the modified integral equation above we will need the volume integral
+operator mapping to points on the boundary, i.e. operator:
 
 ```@example poisson
 using FMM2D #to accelerate the maps
@@ -136,7 +138,8 @@ V_d2b = Inti.volume_potential(;
 )
 ```
 
-as well as the boundary integral operators
+We require also the boundary integral operators for the ensuing integral
+equation:
 
 ```@example poisson
 # Single and double layer operators on Γ
@@ -179,7 +182,7 @@ rhs = g - V_d2b*f
 nothing # hide
 ```
 
-and solve the integral equation for the density function ``σ``:
+and solve the integral equation for the integral density function ``σ``:
 
 ```@example poisson
 using IterativeSolvers, LinearAlgebra
@@ -209,9 +212,10 @@ println("error at $x: ", u(x)-uₑ(x))
 Although we have "solved" the problem in the previous section, using the
 anonymous function `u` to evaluate the field is neither efficient nor accurate
 when there are either many points to evaluate, or when they lie close to the
-boundary ``\Gamma``. The fundamental reason for this is the usual: our
-integral operators are dense matrices, and their evaluation near ``\Gamma``
-suffers from the so-called "near-singularity" problem.
+boundary ``\Gamma``. The fundamental reason for this is the usual: the integral
+operators in the function `u` are dense matrices, and their evaluation inside
+or near to ``\Omega`` suffers from inaccurate singular and near-singular
+quadrature.
 
 To address this issue, we need to assemble *accelerated* and *corrected*
 versions of the integral operators. Let us suppose we wish to evaluate the

--- a/docs/src/examples/poisson.md
+++ b/docs/src/examples/poisson.md
@@ -212,7 +212,7 @@ println("error at $x: ", u(x)-uₑ(x))
 Although we have "solved" the problem in the previous section, using the
 anonymous function `u` to evaluate the field is neither efficient nor accurate
 when there are either many points to evaluate, or when they lie close to the
-boundary ``\Gamma``. The fundamental reason for this is the usual: the integral
+domain ``\Omega``. The fundamental reason for this is the usual: the integral
 operators in the function `u` are dense matrices, and their evaluation inside
 or near to ``\Omega`` suffers from inaccurate singular and near-singular
 quadrature.
@@ -257,7 +257,7 @@ We now evaluate the solution at all mesh nodes and compare it to the manufacture
 ```@example poisson
 u_nodes = V_d2d*f + D_b2d*σ
 er = u_nodes - map(uₑ, target)
-println("maximum error at all mesh nodes:", norm(er, Inf))
+println("maximum error at all mesh nodes: ", norm(er, Inf))
 ```
 
 Lastly, let us visualize the solution and the error:

--- a/docs/src/examples/poisson.md
+++ b/docs/src/examples/poisson.md
@@ -1,0 +1,279 @@
+# Poisson problem
+
+```@meta
+CurrentModule = Inti
+```
+
+!!! note "Important points covered in this example"
+      - Reformulating Poisson-like problems using integral equations
+      - Using volume potentials
+      - Creating interior meshes using Gmsh
+
+## Problem definition
+
+In this example we will solve the Poisson equation in a domain ``\Omega`` with
+Dirichlet boundary conditions on ``\Gamma := \partial \Omega``:
+
+```math
+  \begin{align*}
+      -\Delta u &= f  \quad \text{in } \quad \Omega\\
+      u &= g  \quad \text{on } \quad \Gamma
+  \end{align*}
+```
+
+where ``f : \Omega \to \mathbb{R}`` and ``g : \Gamma \to \mathbb{R}`` are given
+functions.
+
+To solve this problem using integral equations, we split the solution ``u`` into
+a particular solution ``u_p`` and a homogeneous solution ``u_h``:
+
+```math
+  u = u_p + u_h
+```
+
+The function ``u_p`` is given by
+
+```math
+u_p(\boldsymbol{r}) = \int_{\Omega} G(\boldsymbol{r}, \boldsymbol{r'}) f(\boldsymbol{r'}) d\boldsymbol{r'}.
+```
+
+with ``G`` the fundamental solution of ``-\Delta``.
+
+The function ``u_h`` satisfies the homogeneous problem
+
+```math
+  \begin{align*}
+      \Delta u_h &= 0  \quad &&\text{in } \quad \Omega \\
+      u_h &= g - u_p  \quad &&\text{on }  \quad \Gamma
+  \end{align*}
+```
+
+which can be solved using the integral equation method. In particular, for this
+example, we employ a double-layer formulation:
+
+```math
+u_h(\boldsymbol{r}) = \int_{\Gamma} G(\boldsymbol{r}, \boldsymbol{r'}) \sigma(\boldsymbol{r}') d\boldsymbol{r'}.
+```
+
+where the density function ``\sigma`` solves the following integral equation:
+
+```math
+  -\frac{\sigma(\boldsymbol{x})}{2} + \int_{\Gamma} \partial_{\nu_{\boldsymbol{y}}}G(\boldsymbol{x}, \boldsymbol{y}) \sigma(\boldsymbol{y}) \ \mathrm{d} s_{\boldsymbol{y}} = g(\boldsymbol{x}) - u_p(\boldsymbol{x}).
+```
+
+In what follows we will illustrate how to solve the problem above using integral
+equations.
+
+## Geometry and mesh
+
+We use the *Gmsh API* to create a jellyfish shaped domain and to generate a
+second order mesh of its interior and boundary:
+
+```@example poisson
+using Inti, Gmsh
+meshsize = 0.1
+gmsh.initialize()
+jellyfish = Inti.gmsh_curve(0, 2π; meshsize) do s
+    r = 1 + 0.3*cos(4*s + 2*sin(s))
+    return r*Inti.Point2D(cos(s), sin(s))
+end
+cl = gmsh.model.occ.addCurveLoop([jellyfish])
+surf = gmsh.model.occ.addPlaneSurface([cl])
+gmsh.model.occ.synchronize()
+gmsh.option.setNumber("Mesh.MeshSizeMax", meshsize)
+gmsh.model.mesh.generate(2)
+gmsh.model.mesh.setOrder(2)
+msh = Inti.import_mesh(; dim = 2)
+gmsh.finalize()
+```
+
+We can now extract ``\Omega`` and ``\Gamma`` from the mesh:
+
+```@example poisson
+Ω = Inti.Domain(e -> Inti.geometric_dimension(e) == 2, msh)
+Γ = Inti.boundary(Ω)
+Ω_msh = view(msh, Ω)
+Γ_msh = view(msh, Γ)
+nothing #hide
+```
+
+and visualize them:
+
+```@example poisson
+using Meshes, GLMakie
+viz(Ω_msh; showsegments=true)
+viz!(Γ_msh; color=:red)
+Makie.current_figure() #hide
+```
+
+To conclude the geometric setup, we need a quadrature for the volume and
+boundary:
+
+```@example poisson
+Ω_quad = Inti.Quadrature(Ω_msh; qorder = 4)
+Γ_quad = Inti.Quadrature(Γ_msh; qorder = 6)
+nothing # hide
+```
+
+## Integral operators
+
+We can now assemble the required volume potential:
+
+```@example poisson
+using FMM2D #to accelerate the maps
+pde = Inti.Laplace(; dim = 2)
+# Newtonian potential mapping domain to boundary
+V_d2b = Inti.volume_potential(;
+    pde,
+    target = Γ_quad,
+    source = Ω_quad,
+    compression = (method = :fmm, tol = 1e-12),
+    correction = (
+        method = :dim,
+        maxdist = 5 * meshsize,
+        target_location = :on,
+    ),
+)
+```
+
+as well as the boundary integral operators
+
+```@example poisson
+# Single and double layer operators on Γ
+S_b2b, D_b2b = Inti.single_double_layer(;
+    pde,
+    target = Γ_quad,
+    source = Γ_quad,
+    compression = (method = :fmm, tol = 1e-12),
+    correction = (method = :dim,),
+)
+```
+
+!!! note
+    In this example we used the Fast Multipole Method (`:fmm`) to accelerate the
+    operators, and the Density Interpolation Method (`:dim`) to correct singular
+    and nearly-singular integral.
+
+## Solving the linear system
+
+We are now in a position to solve the original Poisson problem, but for that we
+need to specify the functions $f$ and $g$. In order to verify that our numerical
+approximation is correct, however, we will play a different game and specify
+instead a manufactured solution ``u_e`` from which we will derive the functions
+``f`` and ``g``:
+
+```@example poisson
+# Create a manufactured solution
+uₑ = (x) -> cos(2 * x[1]) * sin(2 * x[2])
+fₑ  = (x) -> 8 * cos(2 * x[1]) * sin(2 * x[2]) # -Δuₑ
+g   = map(q -> uₑ(q.coords), Γ_quad)
+f   = map(q -> fₑ(q.coords), Ω_quad)
+nothing # hide
+```
+
+With these, we can compute the right-hand-side of the integral equation for the
+homogeneous part of the solution:
+
+```@example poisson
+rhs = g - V_d2b*f
+nothing # hide
+```
+
+and solve the integral equation for the density function ``σ``:
+
+```@example poisson
+using IterativeSolvers, LinearAlgebra
+σ = gmres(-I/2 + D_b2b, rhs; abstol = 1e-8, verbose = true, restart = 1000)
+nothing # hide
+```
+
+With the density function at hand, we can now reconstruct our approximate solution:
+
+```@example poisson
+G  = Inti.SingleLayerKernel(pde)
+dG = Inti.DoubleLayerKernel(pde)
+𝒱 = Inti.IntegralPotential(G, Ω_quad)
+𝒟 = Inti.IntegralPotential(dG, Γ_quad)
+u = (x) -> 𝒱[f](x) + 𝒟[σ](x)
+```
+
+and evaluate it at any point in the domain:
+
+```@example poisson
+x = Inti.Point2D(0.1,0.4)
+println("error at $x: ", u(x)-uₑ(x))
+```
+
+## Solution evaluation and visualization
+
+Although we have "solved" the problem in the previous section, using the
+anonymous function `u` to evaluate the field is neither efficient nor accurate
+when there are either many points to evaluate, or when they lie close to the
+boundary ``\Gamma``. The fundamental reason for this is the usual: our
+integral operators are dense matrices, and their evaluation near ``\Gamma``
+suffers from the so-called "near-singularity" problem.
+
+To address this issue, we need to assemble *accelerated* and *corrected*
+versions of the integral operators. Let us suppose we wish to evaluate the
+solution ``u`` at all mesh nodes of ``\Omega``, which will be our `target`:
+
+```@example poisson
+target = Inti.nodes(Ω_msh)
+```
+
+We now create a volume operator mapping densities from our domain quadrature to our
+mesh nodes:
+
+```@example poisson
+V_d2d = Inti.volume_potential(;
+    pde,
+    target = target,
+    source = Ω_quad,
+    compression = (method = :fmm, tol = 1e-8),
+    correction = (method = :dim, target_location = :inside, maxdist = meshsize),
+)
+```
+
+Likewise, we need operators mapping densities from our boundary quadrature to
+our mesh nodes:
+
+```@example poisson
+S_b2d, D_b2d = Inti.single_double_layer(;
+    pde,
+    target = target,
+    source = Γ_quad,
+    compression = (method = :fmm, tol = 1e-8),
+    correction = (method = :dim, maxdist = meshsize, target_location = :inside),
+)
+```
+
+We now evaluate the solution at all mesh nodes and compare it to the manufactured:
+
+```@example poisson
+u_nodes = V_d2d*f + D_b2d*σ
+er = u_nodes - map(uₑ, target)
+println("maximum error at all mesh nodes:", norm(er, Inf))
+```
+
+Lastly, let us visualize the solution:
+
+```@example poisson
+colorrange = extrema(u_nodes)
+fig = Figure(; size = (800, 500))
+ax = Axis(fig[1, 1]; aspect = DataAspect())
+viz!(Ω_msh; colorrange, color = u_nodes, interpolate = true)
+cb = Colorbar(fig[1, 2]; label = "u", colorrange)
+fig # hide
+```
+
+as well as the error:
+
+```@example poisson
+colorrange = extrema(er)
+colormap = :inferno
+fig = Figure(; size = (800, 500))
+ax = Axis(fig[1, 1]; aspect = DataAspect())
+viz!(Ω_msh; colorrange, colormap, color = er, interpolate = true)
+cb = Colorbar(fig[1, 2]; label = "u - uₑ", colormap, colorrange)
+fig # hide
+```

--- a/docs/src/examples/poisson.md
+++ b/docs/src/examples/poisson.md
@@ -219,6 +219,7 @@ solution ``u`` at all mesh nodes of ``\Omega``, which will be our `target`:
 
 ```@example poisson
 target = Inti.nodes(Ω_msh)
+nothing # hide
 ```
 
 We now create a volume operator mapping densities from our domain quadrature to our
@@ -255,25 +256,20 @@ er = u_nodes - map(uₑ, target)
 println("maximum error at all mesh nodes:", norm(er, Inf))
 ```
 
-Lastly, let us visualize the solution:
+Lastly, let us visualize the solution and the error:
 
 ```@example poisson
 colorrange = extrema(u_nodes)
-fig = Figure(; size = (800, 500))
+fig = Figure(; size = (800, 300))
 ax = Axis(fig[1, 1]; aspect = DataAspect())
 viz!(Ω_msh; colorrange, color = u_nodes, interpolate = true)
 cb = Colorbar(fig[1, 2]; label = "u", colorrange)
-fig # hide
-```
-
-as well as the error:
-
-```@example poisson
-colorrange = extrema(er)
+# plot error
+log_er = log10.(abs.(er))
+colorrange = extrema(log_er)
 colormap = :inferno
-fig = Figure(; size = (800, 500))
-ax = Axis(fig[1, 1]; aspect = DataAspect())
-viz!(Ω_msh; colorrange, colormap, color = er, interpolate = true)
-cb = Colorbar(fig[1, 2]; label = "u - uₑ", colormap, colorrange)
+ax = Axis(fig[1, 3]; aspect = DataAspect())
+viz!(Ω_msh; colorrange, colormap, color = log_er, interpolate = true)
+cb = Colorbar(fig[1, 4]; label = "log₁₀|u - uₑ|", colormap, colorrange)
 fig # hide
 ```

--- a/docs/src/tutorials/geo_and_meshes.md
+++ b/docs/src/tutorials/geo_and_meshes.md
@@ -86,6 +86,12 @@ viz!(Γ_msh; showsegments = true, alpha = 0.5)
 fig
 ```
 
+!!! warning "Mesh visualization"
+    Note that although the mesh may be of high order and/or conforming, the
+    *visualization* of a mesh is always performed on the underlying first order
+    mesh, and therefore elements may look flat even if the problem is solved on
+    a curved mesh.
+
 ## Parametric entities and `meshgen`
 
 In the previous section we saw an example of how to import a mesh from a file,


### PR DESCRIPTION
Update the Poisson solver example. Note that this example does not use the `Literate` workflow, which I am starting to find a bit cumbersome, but simply writes a standard `.md` file following `Documenter`'s syntax.