### PR TITLE
Improve supported kernels

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Inti"
 uuid = "fb74042b-437e-4c5b-88cf-d4e2beb394d5"
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 Bessels = "0e736298-9ec6-45e8-9647-e4fc86a2fe38"

--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "fb74042b-437e-4c5b-88cf-d4e2beb394d5"
 version = "0.1.1"
 
 [deps]
+Bessels = "0e736298-9ec6-45e8-9647-e4fc86a2fe38"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 ElementaryPDESolutions = "88a69b33-da0f-4502-8c8c-d680cf4d883b"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
@@ -36,6 +37,7 @@ IntiHMatricesExt = "HMatrices"
 IntiMakieExt = ["Meshes", "Makie"]
 
 [compat]
+Bessels = "0.2"
 DataStructures = "0.18"
 ElementaryPDESolutions = "0.2"
 FMM2D = "0.2"

--- a/src/Inti.jl
+++ b/src/Inti.jl
@@ -17,11 +17,11 @@ using QuadGK
 using Scratch
 using SparseArrays
 using StaticArrays
-using SpecialFunctions
 using Printf
 using TOML
 
 import ElementaryPDESolutions
+import SpecialFunctions
 import Bessels # faster than SpecialFunctions for Bessel functions with real args
 
 # helper functions

--- a/src/Inti.jl
+++ b/src/Inti.jl
@@ -22,6 +22,7 @@ using Printf
 using TOML
 
 import ElementaryPDESolutions
+import Bessels # faster than SpecialFunctions for Bessel functions with real args
 
 # helper functions
 include("utils.jl")

--- a/src/kernels.jl
+++ b/src/kernels.jl
@@ -390,7 +390,7 @@ function (HS::HyperSingularKernel{T,S})(target, source)::T where {T,S<:Helmholtz
         val =
             transpose(nx) * (
                 (
-                    -im * k^2 / 4 / d^2 * hankelh1(2, k * d) * r * transpose +
+                    -im * k^2 / 4 / d^2 * hankelh1(2, k * d) * r * transpose(r) +
                     im * k / 4 / d * hankelh1(1, k * d) * I
                 ) * ny
             )

--- a/src/kernels.jl
+++ b/src/kernels.jl
@@ -201,7 +201,7 @@ end
 """
     Yukawa(; λ, dim)
 
-Yukawa equation, also known as modified Helmholtz, in `N` dimensions: Δu + λ²u =
+Yukawa equation, also known as modified Helmholtz, in `N` dimensions: Δu - λ²u =
 0. The parameter `λ` is a positive number.
 """
 function Yukawa(; λ, dim)

--- a/src/kernels.jl
+++ b/src/kernels.jl
@@ -329,6 +329,9 @@ parameters(pde::Helmholtz) = pde.k
 default_kernel_eltype(::Helmholtz) = ComplexF64
 default_density_eltype(::Helmholtz) = ComplexF64
 
+hankelh1(n, x::Real)    = Bessels.hankelh1(n, x)
+hankelh1(n, x::Complex) = SpecialFunctions.hankelh1(n, x)
+
 function (SL::SingleLayerKernel{T,<:Helmholtz{N}})(target, source)::T where {N,T}
     x = coords(target)
     y = coords(source)

--- a/test/kernels_test.jl
+++ b/test/kernels_test.jl
@@ -3,7 +3,7 @@ using Test
 using StaticArrays
 
 @testset "Yukawa" begin
-    for dim in (3,)
+    for dim in (2, 3)
         x = @SVector rand(dim)
         y = @SVector rand(dim)
         nx = @SVector rand(dim)
@@ -14,8 +14,15 @@ using StaticArrays
         k = im * λ
         yuka = Inti.Yukawa(; dim, λ)
         helm = Inti.Helmholtz(; dim, k)
-        for kernel in (Inti.SingleLayerKernel,)
-            @test kernel(yuka)(target, source) ≈ kernel(helm)(target, source)
+        @testset "$dim dimensions" begin
+            for kernel in (
+                Inti.SingleLayerKernel,
+                Inti.DoubleLayerKernel,
+                Inti.AdjointDoubleLayerKernel,
+                Inti.HyperSingularKernel,
+            )
+                @test kernel(yuka)(target, source) ≈ kernel(helm)(target, source)
+            end
         end
     end
 end

--- a/test/kernels_test.jl
+++ b/test/kernels_test.jl
@@ -1,0 +1,21 @@
+using Inti
+using Test
+using StaticArrays
+
+@testset "Yukawa" begin
+    for dim in (3,)
+        x = @SVector rand(dim)
+        y = @SVector rand(dim)
+        nx = @SVector rand(dim)
+        ny = @SVector rand(dim)
+        target = (; coords = x, normal = nx)
+        source = (; coords = y, normal = ny)
+        λ = rand()
+        k = im * λ
+        yuka = Inti.Yukawa(; dim, λ)
+        helm = Inti.Helmholtz(; dim, k)
+        for kernel in (Inti.SingleLayerKernel,)
+            @test kernel(yuka)(target, source) ≈ kernel(helm)(target, source)
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,6 +20,8 @@ using Aqua
 
 @safetestset "Quadrature" include("quadrature_test.jl")
 
+@safetestset "Kernels" include("kernels_test.jl")
+
 @safetestset "Density interpolation method" include("dim_test.jl")
 
 @safetestset "Adaptive integration" include("adaptive_test.jl")


### PR DESCRIPTION
- [x] Create a `Yukawa` kernels for purely imaginary `Helmholtz` problems
- [x] Use `Bessels` to handle Hankel functions with real arguments (faster than `SpecialFunctions`).
- [x] Remove `ifelse` logic to make the kernel return `0` if singular. This avoids the evaluation of functions which may actually throw an error at the origin, such as the `hankelh1(0,0*im)`