### PR TITLE
Updated polynomial solution for Yukawa

### DIFF
--- a/docs/src/examples/cavity2d_scattering.jl
+++ b/docs/src/examples/cavity2d_scattering.jl
@@ -56,7 +56,7 @@ println("Number of quadrature points: ", length(Q))
 ## Setup the integral operators
 op = Inti.Helmholtz(; dim = 2, k)
 S, D = Inti.single_double_layer(;
-    op
+    op,
     target = Q,
     source = Q,
     correction = (method = :none,),

--- a/src/vdim.jl
+++ b/src/vdim.jl
@@ -357,8 +357,14 @@ function polynomial_solution(op::Helmholtz, p::ElementaryPDESolutions.Polynomial
     return ElementaryPDESolutions.convert_coefs(P, Float64)
 end
 
+function polynomial_solution(op::Yukawa, p::ElementaryPDESolutions.Polynomial)
+    k = im*op.λ
+    P = ElementaryPDESolutions.solve_helmholtz(p; k)
+    return ElementaryPDESolutions.convert_coefs(P, Float64)
+end
+
 function neumann_trace(
-    ::Union{Laplace,Helmholtz},
+    ::Union{Laplace,Helmholtz, Yukawa},
     P::ElementaryPDESolutions.Polynomial{N,T},
 ) where {N,T}
     return _normal_derivative(P)


### PR DESCRIPTION
This adds the function polynomial_solution for the Yukawa PDE so that the vdim correction can be used for the volume potential with a Yukawa kernel. In addition, a typo in cavity2d_scattering.jl is fixed.