### PR TITLE
Support for some periodic kernels

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,6 +2,7 @@
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 FMM2D = "2d63477d-9690-4b75-bcc1-c3461d43fecc"
 FMM3D = "1e13804c-f9b7-11ea-0ef0-29f3b1745df8"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
 Gmsh = "705231aa-382f-11e9-3f0c-b7cb4346fdeb"
 HMatrices = "8646bddf-ab1c-4fa7-9c51-ba187d647618"

--- a/test/kernels_test.jl
+++ b/test/kernels_test.jl
@@ -1,6 +1,7 @@
 using Inti
 using Test
 using StaticArrays
+using ForwardDiff
 
 @testset "Yukawa" begin
     for dim in (2, 3)
@@ -25,4 +26,28 @@ using StaticArrays
             end
         end
     end
+end
+
+@testset "Laplace periodic 1d" begin
+    dim     = 2
+    x       = @SVector rand(dim)
+    y       = @SVector rand(dim)
+    nx      = @SVector rand(dim)
+    ny      = @SVector rand(dim)
+    target  = (; coords = x, normal = nx)
+    source  = (; coords = y, normal = ny)
+    period  = rand()
+    op      = Inti.LaplacePeriodic1D(; dim, period)
+    G       = Inti.SingleLayerKernel(op)
+    dGdny   = Inti.DoubleLayerKernel(op)
+    dGdnx   = Inti.AdjointDoubleLayerKernel(op)
+    d2Gdnxy = Inti.HyperSingularKernel(op)
+    # test that the normal derivatives are correct
+    @test ForwardDiff.derivative(t -> G((coords = x + t * nx,), y), 0) ≈
+          dGdnx((coords = x, normal = nx), y)
+    @test ForwardDiff.derivative(t -> G(x, (coords = y + t * ny,)), 0) ≈
+          dGdny(x, (coords = y, normal = ny))
+    # test periodicity
+    @test G(x .+ (period, 0), y) ≈ G(x, y)
+    @test G(x .+ (-3 * period, 0), y) ≈ G(x, y)
 end


### PR DESCRIPTION
This is still very much work in progress, but the goal is to add a some simple periodic kernels to `Inti`. 

I have started with the simplest case, which is the 1d-periodic Laplace problem in 2d, where the exact expression is quite simple (see [this lecture notes](https://people.math.ethz.ch/~grsam/HS17/MaCMiPaP/Lecture%20Notes/Lecture%204.pdf)), but it may be interesting to add e.g. a package extension providing support for quasi-periodic Green functions through [QPGreen.jl](https://github.com/gregoirepourtier/QPGreen.jl).