### PR TITLE
Generic lagrange interpolation

### DIFF
--- a/ext/IntiGmshExt.jl
+++ b/ext/IntiGmshExt.jl
@@ -90,6 +90,15 @@ function _import_mesh!(msh)
             gmsh_ent_tag,
         )
     end
+
+    for (E, mat) in Inti.etype2mat(msh)
+        E <: SVector && continue # skip point type
+        type_tag = _etype_to_type_tag(E)
+        gmsh2inti = _type_tag_to_node_perm(type_tag)
+        for col in eachcol(mat)
+            col .= col[gmsh2inti] # permute the nodes according to the gmsh order
+        end
+    end
     return msh
 end
 
@@ -128,6 +137,36 @@ function _ent_to_mesh!(etype2mat, ent2etags, key, shift, gmsh2loc_node_tags, tgm
         push!(etype2etags, etype => etag)
     end
     return nothing
+end
+
+"""
+    _type_tag_to_node_perm(tag)
+
+Given a Gmsh element type `tag` as an integer, computes the permutation that maps the node
+ordering from Gmsh's reference element to Inti's reference element for the corresponding
+element type.
+"""
+function _type_tag_to_node_perm(tag)
+    E = _type_tag_to_etype(tag) # Inti's type
+    E <: SVector && return [1] # point type, no permutation needed
+    name, dim, order, num_nodes, ref_nodes, num_primary_nodes =
+        gmsh.model.mesh.getElementProperties(tag)
+    dim = Int(dim) # convert to Int64
+    gmsh_nodes = reshape(ref_nodes, Int(dim), :)
+    inti_nodes = Inti.reference_nodes(E)
+    # gmsh uses [-1,1]^dim as reference elements for cuboids, while Inti uses [0,1]^dim, so
+    # shift Inti reference nodes to match gmsh's
+    if Inti.domain(E) isa Inti.ReferenceHyperCube
+        inti_nodes = map(x -> 2 .* x .- 1, inti_nodes) # map to [-1, 1]^dim
+    end
+    perm = map(eachcol(gmsh_nodes)) do col
+        x_gmsh = SVector{dim,Float64}(col)
+        dist, i = findmin(x -> norm(x - x_gmsh), inti_nodes)
+        dist < 1e-8 || error("node $x_gmsh not found in Inti reference nodes")
+        return i
+    end
+    @assert isperm(perm) "permutation is not a valid permutation"
+    return invperm(perm)
 end
 
 """

--- a/src/reference_shapes.jl
+++ b/src/reference_shapes.jl
@@ -17,6 +17,7 @@ Singleton type representing the N-simplex with N+1 vertices
 """
 struct ReferenceSimplex{N} <: ReferenceShape end
 geometric_dimension(::ReferenceSimplex{N}) where {N} = N
+geometric_dimension(::Type{<:ReferenceSimplex{N}}) where {N} = N
 ambient_dimension(::ReferenceSimplex{N}) where {N} = N
 function Base.in(x, ::ReferenceSimplex{N}) where {N}
     for i in 1:N
@@ -55,6 +56,7 @@ the lower corner at the origin and the upper corner at `(1,1,…,1)`.
 """
 struct ReferenceHyperCube{N} <: ReferenceShape end
 geometric_dimension(::ReferenceHyperCube{N}) where {N} = N
+geometric_dimension(::Type{<:ReferenceHyperCube{N}}) where {N} = N
 ambient_dimension(::ReferenceHyperCube{N}) where {N} = N
 Base.in(x, ::ReferenceHyperCube{N}) where {N} = all(0 .≤ x .≤ 1)
 center(::ReferenceHyperCube{N}) where {N} = svector(i -> 0.5, N)

--- a/test/gmsh_test.jl
+++ b/test/gmsh_test.jl
@@ -2,32 +2,86 @@ using Inti
 using Gmsh
 using Test
 
-# for now that check that the code below does not error
-@test begin
-    Inti.clear_entities!()
-    gmsh.initialize()
-    gmsh.option.setNumber("General.Verbosity", 2)
-    gmsh.option.setNumber("Mesh.MeshSizeMax", 0.1)
-    gmsh.model.add("Disk")
-    gmsh.model.occ.addDisk(0, 0, 0, 1, 1)
-    gmsh.model.occ.synchronize()
-    gmsh.model.mesh.generate(2)
-    msh = Inti.import_mesh(; dim = 2)
-    gmsh.finalize()
-    true == true
+@testset "Circle area and perimeter" begin
+    for order in [1, 2, 3]
+        Inti.clear_entities!()
+        gmsh.initialize()
+        gmsh.option.setNumber("General.Verbosity", 2)
+        gmsh.option.setNumber("Mesh.MeshSizeMax", 0.1)
+        gmsh.model.occ.addDisk(0, 0, 0, 1, 1)
+        gmsh.model.occ.synchronize()
+        gmsh.model.mesh.generate(2)
+        gmsh.model.mesh.set_order(order)
+        msh = Inti.import_mesh(; dim = 2)
+        Ω = Inti.Domain(e -> Inti.geometric_dimension(e) == 2, msh)
+        Γ = Inti.boundary(Ω)
+        gmsh.finalize()
+        vol_quad = Inti.Quadrature(msh[Ω]; qorder = 3)
+        bnd_quad = Inti.Quadrature(msh[Γ]; qorder = 3)
+        @test abs(Inti.integrate(x -> 1, vol_quad) - π) < 1e-2
+        @test abs(Inti.integrate(x -> 1, bnd_quad) - 2π) < 1e-2
+    end
 end
 
-@test begin
-    Inti.clear_entities!()
-    gmsh.initialize()
-    gmsh.option.setNumber("General.Verbosity", 2)
-    gmsh.option.setNumber("Mesh.MeshSizeMax", 0.2)
-    gmsh.model.add("Sphere")
-    gmsh.model.occ.addSphere(0, 0, 0, 1)
-    gmsh.model.occ.synchronize()
-    gmsh.model.mesh.generate(3)
-    ents = gmsh.model.getEntities()
-    msh = Inti.import_mesh(; dim = 3)
-    gmsh.finalize()
-    true == true
+@testset "Square area and perimeter" begin
+    for order in [1, 2, 3]
+        Inti.clear_entities!()
+        gmsh.initialize()
+        gmsh.option.setNumber("General.Verbosity", 2)
+        gmsh.option.setNumber("Mesh.MeshSizeMax", 0.1)
+        gmsh.model.occ.addRectangle(-1, -1, 0, 2, 2)
+        gmsh.model.occ.synchronize()
+        gmsh.model.mesh.generate(2)
+        gmsh.model.mesh.set_order(order)
+        msh = Inti.import_mesh(; dim = 2)
+        Ω = Inti.Domain(e -> Inti.geometric_dimension(e) == 2, msh)
+        Γ = Inti.boundary(Ω)
+        gmsh.finalize()
+        vol_quad = Inti.Quadrature(msh[Ω]; qorder = 3)
+        bnd_quad = Inti.Quadrature(msh[Γ]; qorder = 3)
+        @test Inti.integrate(x -> 1, vol_quad) ≈ 4
+        @test Inti.integrate(x -> 1, bnd_quad) ≈ 8
+    end
+end
+
+@testset "Sphere area and volume" begin
+    for order in [2, 3]
+        Inti.clear_entities!()
+        gmsh.initialize()
+        gmsh.option.setNumber("General.Verbosity", 2)
+        gmsh.option.setNumber("Mesh.MeshSizeMax", 0.2)
+        gmsh.model.occ.addSphere(0, 0, 0, 1)
+        gmsh.model.occ.synchronize()
+        gmsh.model.mesh.generate(3)
+        gmsh.model.mesh.set_order(order)
+        msh = Inti.import_mesh(; dim = 3)
+        gmsh.finalize()
+        Ω = Inti.Domain(e -> Inti.geometric_dimension(e) == 3, msh)
+        Γ = Inti.boundary(Ω)
+        vol_quad = Inti.Quadrature(msh[Ω]; qorder = 3)
+        bnd_quad = Inti.Quadrature(msh[Γ]; qorder = 3)
+        @test abs(Inti.integrate(x -> 1, vol_quad) - 4 / 3 * π) < 1e-2
+        @test abs(Inti.integrate(x -> 1, bnd_quad) - 4 * π) < 1e-2
+    end
+end
+
+@testset "Cube area and volume" begin
+    for order in [1, 2, 3]
+        Inti.clear_entities!()
+        gmsh.initialize()
+        gmsh.option.setNumber("General.Verbosity", 2)
+        gmsh.option.setNumber("Mesh.MeshSizeMax", 0.2)
+        gmsh.model.occ.addBox(-1, -1, -1, 2, 2, 2)
+        gmsh.model.occ.synchronize()
+        gmsh.model.mesh.generate(3)
+        gmsh.model.mesh.set_order(order)
+        msh = Inti.import_mesh(; dim = 3)
+        gmsh.finalize()
+        Ω = Inti.Domain(e -> Inti.geometric_dimension(e) == 3, msh)
+        Γ = Inti.boundary(Ω)
+        vol_quad = Inti.Quadrature(msh[Ω]; qorder = 3)
+        bnd_quad = Inti.Quadrature(msh[Γ]; qorder = 3)
+        @test Inti.integrate(x -> 1, vol_quad) ≈ 8
+        @test Inti.integrate(x -> 1, bnd_quad) ≈ 24
+    end
 end

--- a/test/guiggiani_test.jl
+++ b/test/guiggiani_test.jl
@@ -71,8 +71,8 @@ end
     z          = 0.0
     y¹        = SVector(-1.0, -1.0, z)
     y²        = SVector(1.0 + δ, -1.0, z)
-    y³        = SVector(1.0 - δ, 1.0, z)
-    y⁴       = SVector(-1.0, 1.0, z)
+    y³        = SVector(-1.0, 1.0, z)
+    y⁴       = SVector(1.0 - δ, 1.0, z)
     nodes      = (y¹, y², y³, y⁴)
     el         = Inti.LagrangeSquare(nodes)
     ori        = 1


### PR DESCRIPTION
This PR implements $\mathbb{P}_k$ and $\mathbb{Q}_k$ elements generic in both $k$ and the dimension of space. It is essentially a rewrite of some code by @tanderson92 , with some minor tweaks to make it generic and hopefully more efficient. 

Changes include:

- reordering of reference nodes
- permute `gmsh` nodes when importing to adapt to new convention
- generic Pk and Qk methods
- remove hand code versions
- improve tests