### PR TITLE
Change default quadrature rule to VioreanuRokhlin

### DIFF
--- a/docs/src/examples/heat_equation.md
+++ b/docs/src/examples/heat_equation.md
@@ -208,8 +208,8 @@ Now we create quadrature rules for both ``\Omega`` and ``\Gamma``, which will be
 accurately integrate our kernel functions over the domain and boundary:
 
 ```@example heat_equation
-Ω_quad = Inti.Quadrature(Ω_msh; qorder = 3)
-Γ_quad = Inti.Quadrature(Γ_msh; qorder = 3)
+Ω_quad = Inti.Quadrature(Ω_msh; qorder = 2)
+Γ_quad = Inti.Quadrature(Γ_msh; qorder = 2)
 nothing # hide
 ```
 

--- a/docs/src/pluto-examples/helmholtz_scattering.jl
+++ b/docs/src/pluto-examples/helmholtz_scattering.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.20.13
+# v0.20.17
 
 using Markdown
 using InteractiveUtils

--- a/docs/src/pluto-examples/poisson.jl
+++ b/docs/src/pluto-examples/poisson.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.20.13
+# v0.20.17
 
 using Markdown
 using InteractiveUtils

--- a/docs/src/pluto-examples/toy_example.jl
+++ b/docs/src/pluto-examples/toy_example.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.20.13
+# v0.20.17
 
 using Markdown
 using InteractiveUtils

--- a/src/polynomials.jl
+++ b/src/polynomials.jl
@@ -117,8 +117,9 @@ and `0` on nodes `j ≂̸ i` for `1 ≤ i ≤ n`.
 function lagrange_basis(nodes, sp::PolynomialSpace)
     # TODO: use a better basis? For "low" degrees, this is fine, but still...
     basis = monomial_basis(sp)
-    V = hcat([basis(x) for x in nodes]...) # Vandermonde matrix
-    # C = typeof(V)(Matrix(V) \ I) # old way... maybe remove?
+    V = hcat([basis(x) for x in nodes]...)
+    # F = factorize(Matrix(V))
+    # lag_basis = x -> F \ basis(x)
     C = pinv(V)
     lag_basis = x -> C * basis(x)
     return lag_basis

--- a/src/quadrature.jl
+++ b/src/quadrature.jl
@@ -218,9 +218,9 @@ function _qrule_for_reference_shape(ref, order)
         qy = qz = qx
         return TensorProductQuadrature(qx, qy, qz)
     elseif ref isa ReferenceTriangle || ref === :triangle
-        return Gauss(; domain = ref, order = order)
+        return VioreanuRokhlin(; domain = ref, order = order)
     elseif ref isa ReferenceTetrahedron || ref === :tetrahedron
-        return Gauss(; domain = ref, order = order)
+        return VioreanuRokhlin(; domain = ref, order = order)
     else
         error("no appropriate quadrature rule found.")
     end

--- a/test/curved_test_3d.jl
+++ b/test/curved_test_3d.jl
@@ -59,7 +59,7 @@ include("test_utils.jl")
     @test isapprox(Inti.integrate(x -> 1, Ωₕ_quad), truevol, rtol = 1e-7)
     @test isapprox(Inti.integrate(x -> 1, Γₕ_quad), truesfcarea, rtol = 1e-7)
 
-    qorder = 8
+    qorder = 7
     Ωₕ_quad = Inti.Quadrature(Ωₕ; qorder = qorder)
     Γₕ_quad = Inti.Quadrature(Γₕ; qorder = qorder)
     @test isapprox(Inti.integrate(x -> 1, Ωₕ_quad), truevol, rtol = 1e-11)

--- a/test/fmm3d_test.jl
+++ b/test/fmm3d_test.jl
@@ -12,9 +12,9 @@ include("test_utils.jl")
 Ω₂, msh₂ = gmsh_ball(; center = [0.0, 0.0, 0.0], radius = 1.0, meshsize = 0.075)
 # Test on two meshes to test both sources == targets, and not.
 Γ₁ = Inti.external_boundary(Ω₁)
-Γ₁_quad = Inti.Quadrature(view(msh₁, Γ₁); qorder = 3)
+Γ₁_quad = Inti.Quadrature(view(msh₁, Γ₁); qorder = 4)
 Γ₂ = Inti.external_boundary(Ω₂)
-Γ₂_quad = Inti.Quadrature(view(msh₂, Γ₂); qorder = 3)
+Γ₂_quad = Inti.Quadrature(view(msh₂, Γ₂); qorder = 4)
 
 for op in (
     Inti.Laplace(; dim = 3),

--- a/test/gmsh_test.jl
+++ b/test/gmsh_test.jl
@@ -16,7 +16,7 @@ using Test
         Ω = Inti.Domain(e -> Inti.geometric_dimension(e) == 2, msh)
         Γ = Inti.boundary(Ω)
         gmsh.finalize()
-        vol_quad = Inti.Quadrature(msh[Ω]; qorder = 3)
+        vol_quad = Inti.Quadrature(msh[Ω]; qorder = 4)
         bnd_quad = Inti.Quadrature(msh[Γ]; qorder = 3)
         @test abs(Inti.integrate(x -> 1, vol_quad) - π) < 1e-2
         @test abs(Inti.integrate(x -> 1, bnd_quad) - 2π) < 1e-2
@@ -37,7 +37,7 @@ end
         Ω = Inti.Domain(e -> Inti.geometric_dimension(e) == 2, msh)
         Γ = Inti.boundary(Ω)
         gmsh.finalize()
-        vol_quad = Inti.Quadrature(msh[Ω]; qorder = 3)
+        vol_quad = Inti.Quadrature(msh[Ω]; qorder = 4)
         bnd_quad = Inti.Quadrature(msh[Γ]; qorder = 3)
         @test Inti.integrate(x -> 1, vol_quad) ≈ 4
         @test Inti.integrate(x -> 1, bnd_quad) ≈ 8
@@ -59,7 +59,7 @@ end
         Ω = Inti.Domain(e -> Inti.geometric_dimension(e) == 3, msh)
         Γ = Inti.boundary(Ω)
         vol_quad = Inti.Quadrature(msh[Ω]; qorder = 3)
-        bnd_quad = Inti.Quadrature(msh[Γ]; qorder = 3)
+        bnd_quad = Inti.Quadrature(msh[Γ]; qorder = 4)
         @test abs(Inti.integrate(x -> 1, vol_quad) - 4 / 3 * π) < 1e-2
         @test abs(Inti.integrate(x -> 1, bnd_quad) - 4 * π) < 1e-2
     end
@@ -80,7 +80,7 @@ end
         Ω = Inti.Domain(e -> Inti.geometric_dimension(e) == 3, msh)
         Γ = Inti.boundary(Ω)
         vol_quad = Inti.Quadrature(msh[Ω]; qorder = 3)
-        bnd_quad = Inti.Quadrature(msh[Γ]; qorder = 3)
+        bnd_quad = Inti.Quadrature(msh[Γ]; qorder = 4)
         @test Inti.integrate(x -> 1, vol_quad) ≈ 8
         @test Inti.integrate(x -> 1, bnd_quad) ≈ 24
     end

--- a/test/quadrature_test.jl
+++ b/test/quadrature_test.jl
@@ -52,13 +52,13 @@ using Inti
                 return Inti.geometric_dimension(e) == 3
             end
             Γ = Inti.external_boundary(Ω)
-            quad = Inti.Quadrature(M[Γ]; qorder = 4) # NystromMesh of surface Γ
+            quad = Inti.Quadrature(M[Γ]; qorder = 5)
             area = Inti.integrate(x -> 1, quad)
             @test isapprox(area, 4 * π * r^2, rtol = 5e-2)
             exact = map(f, M[Γ].nodes)
             approx = Inti.quadrature_to_node_vals(quad, map(q -> f(q.coords), quad))
             @test exact ≈ approx
-            quad = Inti.Quadrature(M[Ω]; qorder = 4) # Nystrom mesh of volume Ω
+            quad = Inti.Quadrature(M[Ω]; qorder = 5)
             volume = Inti.integrate(x -> 1, quad)
             @test isapprox(volume, 4 / 3 * π * r^3, atol = 1e-2)
             exact = map(f, M[Ω].nodes)


### PR DESCRIPTION
This avoid having quadratures that do not have a unique interpolating polynomial. Users can still use the more efficient `Gauss` quadrature rules by e.g. passing the quadrature rule directly in the constructors of `Quadrature`, but by default when passing a `qorder` keyword argument, we now use `VioreanuRokhlin` quadratures.

Other change:
- Update tests to account for missing quadrature orders
- Fix a typo (tetrehedron -> tetrahedron)