### PR TITLE
translation_and_scaling(): Fixed circumcenter and circumradius calculation

### DIFF
--- a/src/vdim.jl
+++ b/src/vdim.jl
@@ -163,7 +163,7 @@ function translation_and_scaling(el::LagrangeTriangle)
         Cp = vertices[3] - vertices[1]
         Dp = 2 * (Bp[1] * Cp[2] - Bp[2] * Cp[1])
         Upx = 1 / Dp * (Cp[2] * (Bp[1]^2 + Bp[2]^2) - Bp[2] * (Cp[1]^2 + Cp[2]^2))
-        Upy = 1 / Dp * (Bp[1] * (Cp[1]^2 + Cp[2]^2) - Cp[2] * (Bp[1]^2 + Bp[2]^2))
+        Upy = 1 / Dp * (Bp[1] * (Cp[1]^2 + Cp[2]^2) - Cp[1] * (Bp[1]^2 + Bp[2]^2))
         Up = SVector{2}(Upx, Upy)
         r = norm(Up)
         c = Up + vertices[1]


### PR DESCRIPTION
Found and fixed bug with indexing in circumcenter and circumradius calculation in the translation_and_scaling() function.